### PR TITLE
feat(collaboration): add collaboration module and controller

### DIFF
--- a/backend/src/collaboration/collaboration.controller.ts
+++ b/backend/src/collaboration/collaboration.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Controller,
+  Post,
+  Patch,
+  Get,
+  Param,
+  Body,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { CollaborationService } from './collaboration.service';
+import { InviteCollaboratorDto } from './dto/invite-collaborator.dto';
+import { UpdateApprovalDto } from './dto/update-approval.dto';
+import { AuthGuard } from '../auth/guards/auth.guard';
+
+@Controller('collaborations')
+@UseGuards(AuthGuard)
+export class CollaborationController {
+  constructor(
+    private readonly collaborationService: CollaborationService,
+  ) {}
+
+  /**
+   * Invite an artist to collaborate on a track
+   * Only primary artist can do this
+   */
+  @Post('tracks/:trackId/invite')
+  inviteCollaborator(
+    @Param('trackId') trackId: string,
+    @Body() dto: InviteCollaboratorDto,
+    @Req() req,
+  ) {
+    return this.collaborationService.inviteCollaborator(
+      trackId,
+      req.user.id,
+      dto,
+    );
+  }
+
+  /**
+   * Approve or reject a collaboration invite
+   */
+  @Patch(':collaborationId/approval')
+  updateApprovalStatus(
+    @Param('collaborationId') collaborationId: string,
+    @Body() dto: UpdateApprovalDto,
+    @Req() req,
+  ) {
+    return this.collaborationService.updateApprovalStatus(
+      collaborationId,
+      req.user.id,
+      dto.status,
+    );
+  }
+
+  /**
+   * Get all collaborations for a track
+   */
+  @Get('tracks/:trackId')
+  getTrackCollaborations(
+    @Param('trackId') trackId: string,
+  ) {
+    return this.collaborationService.getCollaborationsByTrack(trackId);
+  }
+}

--- a/backend/src/collaboration/collaboration.module.ts
+++ b/backend/src/collaboration/collaboration.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Collaboration } from './collaboration.entity';
+import { CollaborationService } from './collaboration.service';
+import { CollaborationController } from './collaboration.controller';
+import { Track } from '../tracks/track.entity';
+import { Artist } from '../artists/artist.entity';
+import { NotificationModule } from '../notifications/notification.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Collaboration,
+      Track,
+      Artist,
+    ]),
+    NotificationModule,
+  ],
+  controllers: [CollaborationController],
+  providers: [CollaborationService],
+  exports: [CollaborationService],
+})
+export class CollaborationModule {}

--- a/backend/src/collaboration/collaboration.service.ts
+++ b/backend/src/collaboration/collaboration.service.ts
@@ -1,0 +1,284 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Collaboration, ApprovalStatus, CollaborationRole } from './entities/collaboration.entity';
+import { Track } from '../tracks/entities/track.entity';
+import { Artist } from '../artists/entities/artist.entity';
+import { CreateCollaborationDto } from './dto/create-collaboration.dto';
+import { UpdateCollaborationDto } from './dto/update-collaboration.dto';
+import { InviteCollaboratorsDto } from './dto/invite-collaborators.dto';
+import { NotificationService } from '../notifications/notification.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+@Injectable()
+export class CollaborationService {
+  constructor(
+    @InjectRepository(Collaboration)
+    private collaborationRepo: Repository<Collaboration>,
+    @InjectRepository(Track)
+    private trackRepo: Repository<Track>,
+    @InjectRepository(Artist)
+    private artistRepo: Repository<Artist>,
+    private dataSource: DataSource,
+    private notificationService: NotificationService,
+    private eventEmitter: EventEmitter2,
+  ) {}
+
+  async inviteCollaborators(
+    userId: string,
+    dto: InviteCollaboratorsDto,
+  ): Promise<Collaboration[]> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      // Verify track ownership
+      const track = await this.trackRepo.findOne({
+        where: { id: dto.trackId },
+        relations: ['artist'],
+      });
+
+      if (!track) {
+        throw new NotFoundException('Track not found');
+      }
+
+      if (track.artist.userId !== userId) {
+        throw new ForbiddenException('Only track owner can invite collaborators');
+      }
+
+      // Validate total split percentage
+      const existingCollabs = await this.collaborationRepo.find({
+        where: { trackId: dto.trackId, approvalStatus: ApprovalStatus.APPROVED },
+      });
+
+      const existingSplit = existingCollabs.reduce(
+        (sum, collab) => sum + Number(collab.splitPercentage),
+        0,
+      );
+
+      const newSplit = dto.collaborators.reduce(
+        (sum, collab) => sum + collab.splitPercentage,
+        0,
+      );
+
+      // Primary artist should have implicit split
+      const totalSplit = existingSplit + newSplit;
+
+      if (totalSplit > 100) {
+        throw new BadRequestException(
+          `Total split percentage (${totalSplit}%) exceeds 100%. Remaining: ${100 - existingSplit}%`,
+        );
+      }
+
+      // Create collaborations
+      const collaborations: Collaboration[] = [];
+
+      for (const collabDto of dto.collaborators) {
+        // Verify artist exists
+        const artist = await this.artistRepo.findOne({
+          where: { id: collabDto.artistId },
+        });
+
+        if (!artist) {
+          throw new NotFoundException(`Artist ${collabDto.artistId} not found`);
+        }
+
+        // Check for duplicate
+        const existing = await this.collaborationRepo.findOne({
+          where: { trackId: dto.trackId, artistId: collabDto.artistId },
+        });
+
+        if (existing) {
+          throw new BadRequestException(
+            `Artist ${artist.name} is already a collaborator`,
+          );
+        }
+
+        const collaboration = this.collaborationRepo.create({
+          trackId: dto.trackId,
+          artistId: collabDto.artistId,
+          role: collabDto.role,
+          splitPercentage: collabDto.splitPercentage,
+          invitationMessage: collabDto.invitationMessage,
+          approvalStatus: ApprovalStatus.PENDING,
+        });
+
+        const saved = await queryRunner.manager.save(collaboration);
+        collaborations.push(saved);
+
+        // Send notification
+        await this.notificationService.sendCollaborationInvite({
+          artistId: artist.id,
+          trackId: track.id,
+          trackTitle: track.title,
+          invitedBy: track.artist.name,
+          role: collabDto.role,
+          splitPercentage: collabDto.splitPercentage,
+          message: collabDto.invitationMessage,
+        });
+      }
+
+      await queryRunner.commitTransaction();
+
+      this.eventEmitter.emit('collaboration.invited', {
+        trackId: dto.trackId,
+        collaborations,
+      });
+
+      return collaborations;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async respondToInvitation(
+    userId: string,
+    collaborationId: string,
+    dto: UpdateCollaborationDto,
+  ): Promise<Collaboration> {
+    const collaboration = await this.collaborationRepo.findOne({
+      where: { id: collaborationId },
+      relations: ['artist', 'track', 'track.artist'],
+    });
+
+    if (!collaboration) {
+      throw new NotFoundException('Collaboration not found');
+    }
+
+    if (collaboration.artist.userId !== userId) {
+      throw new ForbiddenException('Not authorized to respond to this invitation');
+    }
+
+    if (collaboration.approvalStatus !== ApprovalStatus.PENDING) {
+      throw new BadRequestException('Invitation already responded to');
+    }
+
+    collaboration.approvalStatus = dto.approvalStatus;
+    collaboration.rejectionReason = dto.rejectionReason;
+    collaboration.respondedAt = new Date();
+
+    const updated = await this.collaborationRepo.save(collaboration);
+
+    // Notify track owner
+    await this.notificationService.sendCollaborationResponse({
+      artistId: collaboration.track.artist.id,
+      collaboratorName: collaboration.artist.name,
+      trackTitle: collaboration.track.title,
+      status: dto.approvalStatus,
+      reason: dto.rejectionReason,
+    });
+
+    this.eventEmitter.emit('collaboration.responded', {
+      collaboration: updated,
+      status: dto.approvalStatus,
+    });
+
+    return updated;
+  }
+
+  async getTrackCollaborators(trackId: string): Promise<Collaboration[]> {
+    return this.collaborationRepo.find({
+      where: { trackId },
+      relations: ['artist'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async getArtistCollaborations(artistId: string): Promise<Collaboration[]> {
+    return this.collaborationRepo.find({
+      where: { artistId },
+      relations: ['track', 'track.artist'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getPendingInvitations(userId: string): Promise<Collaboration[]> {
+    const artist = await this.artistRepo.findOne({ where: { userId } });
+    
+    if (!artist) {
+      return [];
+    }
+
+    return this.collaborationRepo.find({
+      where: {
+        artistId: artist.id,
+        approvalStatus: ApprovalStatus.PENDING,
+      },
+      relations: ['track', 'track.artist'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async removeCollaborator(
+    userId: string,
+    collaborationId: string,
+  ): Promise<void> {
+    const collaboration = await this.collaborationRepo.findOne({
+      where: { id: collaborationId },
+      relations: ['track', 'track.artist'],
+    });
+
+    if (!collaboration) {
+      throw new NotFoundException('Collaboration not found');
+    }
+
+    // Only track owner can remove collaborators
+    if (collaboration.track.artist.userId !== userId) {
+      throw new ForbiddenException('Only track owner can remove collaborators');
+    }
+
+    await this.collaborationRepo.remove(collaboration);
+
+    this.eventEmitter.emit('collaboration.removed', {
+      collaborationId,
+      trackId: collaboration.trackId,
+    });
+  }
+
+  async validateSplitPercentages(trackId: string): Promise<{
+    isValid: boolean;
+    total: number;
+    remaining: number;
+  }> {
+    const collaborations = await this.collaborationRepo.find({
+      where: { trackId, approvalStatus: ApprovalStatus.APPROVED },
+    });
+
+    const total = collaborations.reduce(
+      (sum, collab) => sum + Number(collab.splitPercentage),
+      0,
+    );
+
+    return {
+      isValid: total <= 100,
+      total,
+      remaining: 100 - total,
+    };
+  }
+
+  async getCollaborationStats(trackId: string) {
+    const collaborations = await this.getTrackCollaborators(trackId);
+
+    return {
+      total: collaborations.length,
+      approved: collaborations.filter((c) => c.approvalStatus === ApprovalStatus.APPROVED)
+        .length,
+      pending: collaborations.filter((c) => c.approvalStatus === ApprovalStatus.PENDING)
+        .length,
+      rejected: collaborations.filter((c) => c.approvalStatus === ApprovalStatus.REJECTED)
+        .length,
+      splitAllocated: collaborations
+        .filter((c) => c.approvalStatus === ApprovalStatus.APPROVED)
+        .reduce((sum, c) => sum + Number(c.splitPercentage), 0),
+    };
+  }
+}

--- a/backend/src/collaboration/dto/collaboration-response.dto.ts
+++ b/backend/src/collaboration/dto/collaboration-response.dto.ts
@@ -1,0 +1,14 @@
+export class CollaborationResponseDto {
+  id: string;
+  trackId: string;
+  artistId: string;
+  artistName: string;
+  artistUsername: string;
+  role: CollaborationRole;
+  splitPercentage: number;
+  approvalStatus: ApprovalStatus;
+  invitationMessage?: string;
+  rejectionReason?: string;
+  respondedAt?: Date;
+  createdAt: Date;
+}

--- a/backend/src/collaboration/dto/create-collaboration.dto.ts
+++ b/backend/src/collaboration/dto/create-collaboration.dto.ts
@@ -1,0 +1,22 @@
+import { IsUUID, IsEnum, IsNumber, Min, Max, IsOptional, IsString } from 'class-validator';
+import { CollaborationRole } from '../entities/collaboration.entity';
+
+export class CreateCollaborationDto {
+  @IsUUID()
+  trackId: string;
+
+  @IsUUID()
+  artistId: string;
+
+  @IsEnum(CollaborationRole)
+  role: CollaborationRole;
+
+  @IsNumber()
+  @Min(0.01)
+  @Max(100)
+  splitPercentage: number;
+
+  @IsOptional()
+  @IsString()
+  invitationMessage?: string;
+}

--- a/backend/src/collaboration/dto/invite-collaborators.dto.ts
+++ b/backend/src/collaboration/dto/invite-collaborators.dto.ts
@@ -1,0 +1,29 @@
+import { Type } from 'class-transformer';
+import { ValidateNested, ArrayMinSize, IsUUID } from 'class-validator';
+
+class CollaboratorInvite {
+  @IsUUID()
+  artistId: string;
+
+  @IsEnum(CollaborationRole)
+  role: CollaborationRole;
+
+  @IsNumber()
+  @Min(0.01)
+  @Max(100)
+  splitPercentage: number;
+
+  @IsOptional()
+  @IsString()
+  invitationMessage?: string;
+}
+
+export class InviteCollaboratorsDto {
+  @IsUUID()
+  trackId: string;
+
+  @ValidateNested({ each: true })
+  @Type(() => CollaboratorInvite)
+  @ArrayMinSize(1)
+  collaborators: CollaboratorInvite[];
+}

--- a/backend/src/collaboration/dto/update-collaboration.dto.ts
+++ b/backend/src/collaboration/dto/update-collaboration.dto.ts
@@ -1,0 +1,11 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { ApprovalStatus } from '../entities/collaboration.entity';
+
+export class UpdateCollaborationDto {
+  @IsEnum(ApprovalStatus)
+  approvalStatus: ApprovalStatus;
+
+  @IsOptional()
+  @IsString()
+  rejectionReason?: string;
+}

--- a/backend/src/collaboration/entities/collaboration.entity.ts
+++ b/backend/src/collaboration/entities/collaboration.entity.ts
@@ -1,0 +1,81 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { Track } from '../../tracks/entities/track.entity';
+import { Artist } from '../../artists/entities/artist.entity';
+
+export enum CollaborationRole {
+  PRIMARY = 'primary',
+  FEATURED = 'featured',
+  PRODUCER = 'producer',
+  COMPOSER = 'composer',
+  MIXER = 'mixer',
+}
+
+export enum ApprovalStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+}
+
+@Entity('collaborations')
+@Index(['trackId', 'artistId'], { unique: true })
+export class Collaboration {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  trackId: string;
+
+  @ManyToOne(() => Track, (track) => track.collaborations, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'trackId' })
+  track: Track;
+
+  @Column('uuid')
+  artistId: string;
+
+  @ManyToOne(() => Artist, (artist) => artist.collaborations)
+  @JoinColumn({ name: 'artistId' })
+  artist: Artist;
+
+  @Column({
+    type: 'enum',
+    enum: CollaborationRole,
+    default: CollaborationRole.FEATURED,
+  })
+  role: CollaborationRole;
+
+  @Column('decimal', { precision: 5, scale: 2 })
+  splitPercentage: number;
+
+  @Column({
+    type: 'enum',
+    enum: ApprovalStatus,
+    default: ApprovalStatus.PENDING,
+  })
+  approvalStatus: ApprovalStatus;
+
+  @Column({ type: 'text', nullable: true })
+  invitationMessage: string;
+
+  @Column({ type: 'text', nullable: true })
+  rejectionReason: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  respondedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/tips/tip-distribution.service.ts
+++ b/backend/src/tips/tip-distribution.service.ts
@@ -1,0 +1,290 @@
+// src/tips/tip-distribution.service.ts
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Collaboration, ApprovalStatus } from '../collaboration/entities/collaboration.entity';
+import { Tip } from './entities/tip.entity';
+import { Track } from '../tracks/entities/track.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+interface SplitRecipient {
+  artistId: string;
+  artistName: string;
+  publicKey: string;
+  percentage: number;
+  amount: number;
+  role: string;
+}
+
+interface DistributionResult {
+  tipId: string;
+  trackId: string;
+  totalAmount: number;
+  recipients: SplitRecipient[];
+  transactionHash: string;
+  distributedAt: Date;
+}
+
+@Injectable()
+export class TipDistributionService {
+  constructor(
+    @InjectRepository(Collaboration)
+    private collaborationRepo: Repository<Collaboration>,
+    @InjectRepository(Tip)
+    private tipRepo: Repository<Tip>,
+    @InjectRepository(Track)
+    private trackRepo: Repository<Track>,
+    private stellarService: StellarService,
+    private dataSource: DataSource,
+    private eventEmitter: EventEmitter2,
+  ) {}
+
+  async distributeTip(tipId: string): Promise<DistributionResult> {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      // Get tip details
+      const tip = await this.tipRepo.findOne({
+        where: { id: tipId },
+        relations: ['track', 'track.artist', 'user'],
+      });
+
+      if (!tip) {
+        throw new BadRequestException('Tip not found');
+      }
+
+      if (tip.distributedAt) {
+        throw new BadRequestException('Tip already distributed');
+      }
+
+      // Get approved collaborations
+      const collaborations = await this.collaborationRepo.find({
+        where: {
+          trackId: tip.trackId,
+          approvalStatus: ApprovalStatus.APPROVED,
+        },
+        relations: ['artist'],
+      });
+
+      // Calculate splits
+      const recipients = await this.calculateSplits(
+        tip,
+        collaborations,
+      );
+
+      // Validate total percentage
+      const totalPercentage = recipients.reduce(
+        (sum, r) => sum + r.percentage,
+        0,
+      );
+
+      if (Math.abs(totalPercentage - 100) > 0.01) {
+        throw new BadRequestException(
+          `Invalid split percentages: total is ${totalPercentage}%`,
+        );
+      }
+
+      // Execute Stellar multi-recipient payment
+      const transactionHash = await this.stellarService.sendMultiRecipientPayment(
+        recipients.map((r) => ({
+          destination: r.publicKey,
+          amount: r.amount.toString(),
+        })),
+        tip.transactionHash, // Source transaction reference
+      );
+
+      // Update tip as distributed
+      tip.distributedAt = new Date();
+      tip.distributionHash = transactionHash;
+      await queryRunner.manager.save(tip);
+
+      await queryRunner.commitTransaction();
+
+      const result: DistributionResult = {
+        tipId: tip.id,
+        trackId: tip.trackId,
+        totalAmount: Number(tip.amount),
+        recipients,
+        transactionHash,
+        distributedAt: tip.distributedAt,
+      };
+
+      // Emit event for notifications
+      this.eventEmitter.emit('tip.distributed', result);
+
+      return result;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async calculateSplits(
+    tip: Tip,
+    collaborations: Collaboration[],
+  ): Promise<SplitRecipient[]> {
+    const recipients: SplitRecipient[] = [];
+    const totalAmount = Number(tip.amount);
+
+    // Calculate collaborator splits
+    const collaboratorTotal = collaborations.reduce(
+      (sum, c) => sum + Number(c.splitPercentage),
+      0,
+    );
+
+    for (const collab of collaborations) {
+      const percentage = Number(collab.splitPercentage);
+      const amount = (totalAmount * percentage) / 100;
+
+      recipients.push({
+        artistId: collab.artistId,
+        artistName: collab.artist.name,
+        publicKey: collab.artist.stellarPublicKey,
+        percentage,
+        amount: Number(amount.toFixed(7)), // Stellar 7 decimal precision
+        role: collab.role,
+      });
+    }
+
+    // Primary artist gets remaining percentage
+    const primaryPercentage = 100 - collaboratorTotal;
+    if (primaryPercentage > 0) {
+      const primaryAmount = (totalAmount * primaryPercentage) / 100;
+
+      recipients.push({
+        artistId: tip.track.artist.id,
+        artistName: tip.track.artist.name,
+        publicKey: tip.track.artist.stellarPublicKey,
+        percentage: primaryPercentage,
+        amount: Number(primaryAmount.toFixed(7)),
+        role: 'primary',
+      });
+    }
+
+    return recipients;
+  }
+
+  async getDistributionHistory(trackId: string): Promise<DistributionResult[]> {
+    const tips = await this.tipRepo.find({
+      where: { trackId, distributedAt: Not(null) },
+      relations: ['track', 'track.artist'],
+      order: { distributedAt: 'DESC' },
+    });
+
+    const history: DistributionResult[] = [];
+
+    for (const tip of tips) {
+      const collaborations = await this.collaborationRepo.find({
+        where: {
+          trackId: tip.trackId,
+          approvalStatus: ApprovalStatus.APPROVED,
+        },
+        relations: ['artist'],
+      });
+
+      const recipients = await this.calculateSplits(tip, collaborations);
+
+      history.push({
+        tipId: tip.id,
+        trackId: tip.trackId,
+        totalAmount: Number(tip.amount),
+        recipients,
+        transactionHash: tip.distributionHash,
+        distributedAt: tip.distributedAt,
+      });
+    }
+
+    return history;
+  }
+
+  async getArtistEarnings(artistId: string, trackId?: string) {
+    let query = this.tipRepo
+      .createQueryBuilder('tip')
+      .leftJoin('tip.track', 'track')
+      .leftJoin('track.collaborations', 'collab')
+      .where('tip.distributedAt IS NOT NULL')
+      .andWhere(
+        '(track.artistId = :artistId OR (collab.artistId = :artistId AND collab.approvalStatus = :approved))',
+        { artistId, approved: ApprovalStatus.APPROVED },
+      );
+
+    if (trackId) {
+      query = query.andWhere('tip.trackId = :trackId', { trackId });
+    }
+
+    const tips = await query.getMany();
+
+    let totalEarnings = 0;
+    const breakdown = [];
+
+    for (const tip of tips) {
+      const collaborations = await this.collaborationRepo.find({
+        where: {
+          trackId: tip.trackId,
+          approvalStatus: ApprovalStatus.APPROVED,
+        },
+        relations: ['artist'],
+      });
+
+      const recipients = await this.calculateSplits(tip, collaborations);
+      const artistShare = recipients.find((r) => r.artistId === artistId);
+
+      if (artistShare) {
+        totalEarnings += artistShare.amount;
+        breakdown.push({
+          tipId: tip.id,
+          trackId: tip.trackId,
+          amount: artistShare.amount,
+          percentage: artistShare.percentage,
+          role: artistShare.role,
+          distributedAt: tip.distributedAt,
+        });
+      }
+    }
+
+    return {
+      artistId,
+      totalEarnings,
+      tipCount: breakdown.length,
+      breakdown,
+    };
+  }
+
+  async getPendingDistributions(trackId?: string) {
+    let query = this.tipRepo
+      .createQueryBuilder('tip')
+      .where('tip.distributedAt IS NULL')
+      .andWhere('tip.status = :status', { status: 'completed' });
+
+    if (trackId) {
+      query = query.andWhere('tip.trackId = :trackId', { trackId });
+    }
+
+    return query
+      .leftJoinAndSelect('tip.track', 'track')
+      .leftJoinAndSelect('track.artist', 'artist')
+      .getMany();
+  }
+
+  async distributeAllPending(trackId?: string): Promise<DistributionResult[]> {
+    const pendingTips = await this.getPendingDistributions(trackId);
+    const results: DistributionResult[] = [];
+
+    for (const tip of pendingTips) {
+      try {
+        const result = await this.distributeTip(tip.id);
+        results.push(result);
+      } catch (error) {
+        console.error(`Failed to distribute tip ${tip.id}:`, error.message);
+      }
+    }
+
+    return results;
+  }
+}
+


### PR DESCRIPTION

Implements the collaboration feature that allows multiple artists to collaborate on a track and automatically split tips.

### Key Features
- Collaboration entity and module
- Invite collaborators with split percentages
- Approval / rejection workflow
- Track-level collaboration listing
- Backend foundation for Stellar multi-recipient payments

### Technical Notes
- Percentage validation handled at service level
- Approval required before tips can be distributed
- Designed to support atomic Stellar transactions
closes #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track collaboration management: invite collaborators to tracks, assign roles, and set split percentages
  * Collaboration approval workflow: collaborators can approve or reject invitations
  * Track collaborations view: retrieve all collaborators and their details for a track
  * Tip distribution among collaborators: automatically distribute tips based on approved split percentages
  * Earnings tracking: view distribution history and artist earnings from collaborations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->