### PR TITLE
feat(analytics): build analytics service for tip data aggregation and…

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,126 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+  Res,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { Response } from 'express';
+import { AnalyticsService } from './analytics.service';
+import {
+  AnalyticsQueryDto,
+  TrendsQueryDto,
+  RankingsQueryDto,
+  AnalyticsPeriod,
+} from './dto/analytics-query.dto';
+import {
+  TipSummaryDto,
+  TrendsResponseDto,
+  RankingsResponseDto,
+  GenreDistributionResponseDto,
+  ArtistAnalyticsDto,
+} from './dto/analytics-response.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('analytics')
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('tips/summary')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tip summary statistics' })
+  @ApiQuery({ name: 'period', enum: AnalyticsPeriod, required: false })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  @ApiQuery({ name: 'artistId', required: false })
+  @ApiResponse({ status: 200, description: 'Tip summary data' })
+  async getTipSummary(@Query() query: AnalyticsQueryDto): Promise<TipSummaryDto> {
+    return this.analyticsService.getTipSummary(query);
+  }
+
+  @Get('tips/trends')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tip trends over time' })
+  @ApiQuery({ name: 'period', enum: AnalyticsPeriod, required: false })
+  @ApiQuery({ name: 'groupBy', enum: ['hour', 'day', 'week', 'month'], required: false })
+  @ApiQuery({ name: 'artistId', required: false })
+  @ApiResponse({ status: 200, description: 'Tip trends data' })
+  async getTipTrends(@Query() query: TrendsQueryDto): Promise<TrendsResponseDto> {
+    return this.analyticsService.getTipTrends(query);
+  }
+
+  @Get('artists/rankings')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get artist rankings by tips received' })
+  @ApiQuery({ name: 'period', enum: AnalyticsPeriod, required: false })
+  @ApiQuery({ name: 'limit', type: Number, required: false })
+  @ApiQuery({ name: 'offset', type: Number, required: false })
+  @ApiQuery({ name: 'genre', required: false })
+  @ApiResponse({ status: 200, description: 'Artist rankings' })
+  async getArtistRankings(@Query() query: RankingsQueryDto): Promise<RankingsResponseDto> {
+    return this.analyticsService.getArtistRankings(query);
+  }
+
+  @Get('genres/distribution')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get tip distribution by genre' })
+  @ApiQuery({ name: 'period', enum: AnalyticsPeriod, required: false })
+  @ApiResponse({ status: 200, description: 'Genre distribution data' })
+  async getGenreDistribution(
+    @Query() query: AnalyticsQueryDto,
+  ): Promise<GenreDistributionResponseDto> {
+    return this.analyticsService.getGenreDistribution(query);
+  }
+
+  @Get('artists/:id/analytics')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get detailed analytics for a specific artist' })
+  @ApiResponse({ status: 200, description: 'Artist analytics' })
+  @ApiResponse({ status: 404, description: 'Artist not found' })
+  async getArtistAnalytics(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ArtistAnalyticsDto> {
+    return this.analyticsService.getArtistAnalytics(id);
+  }
+
+  @Get('export/:type')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Export analytics report' })
+  @ApiQuery({ name: 'format', enum: ['csv', 'json', 'xlsx'], required: false })
+  @ApiQuery({ name: 'period', enum: AnalyticsPeriod, required: false })
+  async exportReport(
+    @Param('type') type: 'tips' | 'artists' | 'genres',
+    @Query('format') format: 'csv' | 'json' | 'xlsx' = 'json',
+    @Query() query: AnalyticsQueryDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const report = await this.analyticsService.exportReport(type, query, format);
+
+    const contentType =
+      format === 'csv'
+        ? 'text/csv'
+        : format === 'xlsx'
+        ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        : 'application/json';
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="${report.filename}"`);
+
+    if (format === 'json') {
+      res.status(HttpStatus.OK).json(report.data);
+    } else {
+      res.status(HttpStatus.OK).send(report.data);
+    }
+  }
+}

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsScheduler } from './analytics.scheduler';
+import { Tip } from '../tips/entities/tip.entity';
+import { Artist } from '../artists/entities/artist.entity';
+import { Track } from '../tracks/entities/track.entity';
+import { Genre } from '../genres/entities/genre.entity';
+import { RedisModule } from '../leaderboards/redis.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Tip, Artist, Track, Genre]),
+    RedisModule,
+  ],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService, AnalyticsScheduler],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/backend/src/analytics/analytics.scheduler.ts
+++ b/backend/src/analytics/analytics.scheduler.ts
@@ -1,0 +1,133 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsPeriod, AnalyticsGroupBy } from './dto/analytics-query.dto';
+
+/**
+ * Scheduled tasks for pre-computing and caching analytics data
+ */
+@Injectable()
+export class AnalyticsScheduler {
+  private readonly logger = new Logger(AnalyticsScheduler.name);
+
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  /**
+   * Pre-compute daily analytics every hour
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async precomputeDailyAnalytics() {
+    this.logger.log('Pre-computing daily analytics');
+    try {
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.DAY });
+      await this.analyticsService.getTipTrends({ 
+        period: AnalyticsPeriod.DAY, 
+        groupBy: AnalyticsGroupBy.HOUR 
+      });
+      this.logger.log('Daily analytics pre-computed successfully');
+    } catch (error) {
+      this.logger.error('Error pre-computing daily analytics', error);
+    }
+  }
+
+  /**
+   * Pre-compute weekly analytics every 6 hours
+   */
+  @Cron(CronExpression.EVERY_6_HOURS)
+  async precomputeWeeklyAnalytics() {
+    this.logger.log('Pre-computing weekly analytics');
+    try {
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.WEEK });
+      await this.analyticsService.getTipTrends({ 
+        period: AnalyticsPeriod.WEEK, 
+        groupBy: AnalyticsGroupBy.DAY 
+      });
+      await this.analyticsService.getArtistRankings({ 
+        period: AnalyticsPeriod.WEEK, 
+        limit: 100 
+      });
+      await this.analyticsService.getGenreDistribution({ period: AnalyticsPeriod.WEEK });
+      this.logger.log('Weekly analytics pre-computed successfully');
+    } catch (error) {
+      this.logger.error('Error pre-computing weekly analytics', error);
+    }
+  }
+
+  /**
+   * Pre-compute monthly analytics every 12 hours
+   */
+  @Cron('0 0 */12 * * *')
+  async precomputeMonthlyAnalytics() {
+    this.logger.log('Pre-computing monthly analytics');
+    try {
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.MONTH });
+      await this.analyticsService.getTipTrends({ 
+        period: AnalyticsPeriod.MONTH, 
+        groupBy: AnalyticsGroupBy.DAY 
+      });
+      await this.analyticsService.getArtistRankings({ 
+        period: AnalyticsPeriod.MONTH, 
+        limit: 100 
+      });
+      await this.analyticsService.getGenreDistribution({ period: AnalyticsPeriod.MONTH });
+      this.logger.log('Monthly analytics pre-computed successfully');
+    } catch (error) {
+      this.logger.error('Error pre-computing monthly analytics', error);
+    }
+  }
+
+  /**
+   * Pre-compute quarterly and yearly analytics daily
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async precomputeLongTermAnalytics() {
+    this.logger.log('Pre-computing long-term analytics');
+    try {
+      // Quarterly
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.QUARTER });
+      await this.analyticsService.getTipTrends({ 
+        period: AnalyticsPeriod.QUARTER, 
+        groupBy: AnalyticsGroupBy.WEEK 
+      });
+      await this.analyticsService.getArtistRankings({ 
+        period: AnalyticsPeriod.QUARTER, 
+        limit: 100 
+      });
+
+      // Yearly
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.YEAR });
+      await this.analyticsService.getTipTrends({ 
+        period: AnalyticsPeriod.YEAR, 
+        groupBy: AnalyticsGroupBy.MONTH 
+      });
+      await this.analyticsService.getArtistRankings({ 
+        period: AnalyticsPeriod.YEAR, 
+        limit: 100 
+      });
+      await this.analyticsService.getGenreDistribution({ period: AnalyticsPeriod.YEAR });
+
+      this.logger.log('Long-term analytics pre-computed successfully');
+    } catch (error) {
+      this.logger.error('Error pre-computing long-term analytics', error);
+    }
+  }
+
+  /**
+   * Refresh all-time analytics weekly
+   */
+  @Cron(CronExpression.EVERY_WEEK)
+  async precomputeAllTimeAnalytics() {
+    this.logger.log('Pre-computing all-time analytics');
+    try {
+      await this.analyticsService.getTipSummary({ period: AnalyticsPeriod.ALL });
+      await this.analyticsService.getArtistRankings({ 
+        period: AnalyticsPeriod.ALL, 
+        limit: 100 
+      });
+      await this.analyticsService.getGenreDistribution({ period: AnalyticsPeriod.ALL });
+      this.logger.log('All-time analytics pre-computed successfully');
+    } catch (error) {
+      this.logger.error('Error pre-computing all-time analytics', error);
+    }
+  }
+}

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,323 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AnalyticsService } from './analytics.service';
+import { Tip, TipStatus } from '../tips/entities/tip.entity';
+import { Artist } from '../artists/entities/artist.entity';
+import { Track } from '../tracks/entities/track.entity';
+import { Genre } from '../genres/entities/genre.entity';
+import { REDIS_CLIENT } from '../leaderboards/redis.module';
+import { AnalyticsPeriod, AnalyticsGroupBy } from './dto/analytics-query.dto';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+  let tipRepository: Repository<Tip>;
+  let artistRepository: Repository<Artist>;
+  let redisClient: any;
+
+  const mockRedisClient = {
+    get: jest.fn(),
+    setex: jest.fn(),
+    del: jest.fn(),
+    keys: jest.fn(),
+  };
+
+  const mockTipRepository = {
+    createQueryBuilder: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn(),
+      getRawMany: jest.fn(),
+      getOne: jest.fn(),
+      getMany: jest.fn(),
+    })),
+  };
+
+  const mockArtistRepository = {
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(() => ({
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn(),
+    })),
+  };
+
+  const mockTrackRepository = {};
+  const mockGenreRepository = {};
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        {
+          provide: getRepositoryToken(Tip),
+          useValue: mockTipRepository,
+        },
+        {
+          provide: getRepositoryToken(Artist),
+          useValue: mockArtistRepository,
+        },
+        {
+          provide: getRepositoryToken(Track),
+          useValue: mockTrackRepository,
+        },
+        {
+          provide: getRepositoryToken(Genre),
+          useValue: mockGenreRepository,
+        },
+        {
+          provide: REDIS_CLIENT,
+          useValue: mockRedisClient,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+    tipRepository = module.get<Repository<Tip>>(getRepositoryToken(Tip));
+    artistRepository = module.get<Repository<Artist>>(getRepositoryToken(Artist));
+    redisClient = module.get(REDIS_CLIENT);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getTipSummary', () => {
+    it('should return cached data if available', async () => {
+      const cachedData = {
+        totalTips: 100,
+        totalAmount: 5000,
+        averageTipAmount: 50,
+        uniqueTippers: 50,
+        uniqueArtists: 20,
+        periodStart: new Date(),
+        periodEnd: new Date(),
+      };
+      mockRedisClient.get.mockResolvedValue(JSON.stringify(cachedData));
+
+      const result = await service.getTipSummary({ period: AnalyticsPeriod.WEEK });
+
+      expect(result).toEqual(cachedData);
+      expect(mockRedisClient.get).toHaveBeenCalled();
+      expect(mockTipRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should compute and cache tip summary', async () => {
+      mockRedisClient.get.mockResolvedValue(null);
+      const mockQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockQueryBuilder.getRawOne.mockResolvedValue({
+        totalTips: '100',
+        totalAmount: '5000',
+        averageTipAmount: '50',
+        uniqueTippers: '50',
+        uniqueArtists: '20',
+      });
+
+      const result = await service.getTipSummary({ period: AnalyticsPeriod.WEEK });
+
+      expect(result.totalTips).toBe(100);
+      expect(result.totalAmount).toBe(5000);
+      expect(mockRedisClient.setex).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTipTrends', () => {
+    it('should return tip trends with growth rate', async () => {
+      mockRedisClient.get.mockResolvedValue(null);
+      const mockQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { timestamp: new Date(), tipCount: '10', totalAmount: '500', uniqueTippers: '5' },
+        { timestamp: new Date(), tipCount: '15', totalAmount: '750', uniqueTippers: '8' },
+        { timestamp: new Date(), tipCount: '20', totalAmount: '1000', uniqueTippers: '10' },
+        { timestamp: new Date(), tipCount: '25', totalAmount: '1250', uniqueTippers: '12' },
+      ]);
+
+      const result = await service.getTipTrends({ 
+        period: AnalyticsPeriod.WEEK,
+        groupBy: AnalyticsGroupBy.DAY 
+      });
+
+      expect(result.data).toHaveLength(4);
+      expect(result.summary.totalTips).toBe(70);
+      expect(result.summary.totalAmount).toBe(3500);
+      expect(result.summary.growthRate).toBeDefined();
+    });
+  });
+
+  describe('getArtistRankings', () => {
+    it('should return artist rankings', async () => {
+      mockRedisClient.get.mockResolvedValue(null);
+      const mockQueryBuilder = mockArtistRepository.createQueryBuilder();
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        {
+          artistId: 'artist-1',
+          artistName: 'Artist One',
+          profileImage: 'image1.jpg',
+          genre: 'Rock',
+          totalAmount: '1000',
+          totalTips: '20',
+          averageTipAmount: '50',
+          uniqueTippers: '15',
+        },
+        {
+          artistId: 'artist-2',
+          artistName: 'Artist Two',
+          profileImage: 'image2.jpg',
+          genre: 'Pop',
+          totalAmount: '800',
+          totalTips: '16',
+          averageTipAmount: '50',
+          uniqueTippers: '12',
+        },
+      ]);
+
+      const result = await service.getArtistRankings({ 
+        period: AnalyticsPeriod.WEEK,
+        limit: 10 
+      });
+
+      expect(result.rankings).toHaveLength(2);
+      expect(result.rankings[0].rank).toBe(1);
+      expect(result.rankings[0].artistName).toBe('Artist One');
+      expect(result.rankings[1].rank).toBe(2);
+    });
+  });
+
+  describe('getGenreDistribution', () => {
+    it('should return genre distribution', async () => {
+      mockRedisClient.get.mockResolvedValue(null);
+      const mockQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { genre: 'Rock', tipCount: '50', totalAmount: '2500', artistCount: '10' },
+        { genre: 'Pop', tipCount: '40', totalAmount: '2000', artistCount: '8' },
+        { genre: 'Jazz', tipCount: '30', totalAmount: '1500', artistCount: '6' },
+      ]);
+
+      const result = await service.getGenreDistribution({ period: AnalyticsPeriod.WEEK });
+
+      expect(result.distribution).toHaveLength(3);
+      expect(result.totalAmount).toBe(6000);
+      expect(result.distribution[0].percentage).toBe(41.67);
+    });
+  });
+
+  describe('getArtistAnalytics', () => {
+    it('should throw error if artist not found', async () => {
+      mockArtistRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getArtistAnalytics('non-existent-id')).rejects.toThrow('Artist not found');
+    });
+
+    it('should return detailed artist analytics', async () => {
+      mockArtistRepository.findOne.mockResolvedValue({
+        id: 'artist-1',
+        artistName: 'Test Artist',
+      });
+
+      const mockTipQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockTipQueryBuilder.getRawOne.mockResolvedValue({
+        totalTips: '50',
+        totalAmount: '2500',
+        averageTipAmount: '50',
+        uniqueTippers: '30',
+      });
+
+      // For top tippers
+      mockTipQueryBuilder.getRawMany.mockResolvedValue([
+        { userId: 'user-1', totalAmount: '500', tipCount: '10' },
+        { userId: 'user-2', totalAmount: '300', tipCount: '6' },
+      ]);
+
+      const result = await service.getArtistAnalytics('artist-1');
+
+      expect(result.artistName).toBe('Test Artist');
+      expect(result.totalTips).toBe(50);
+      expect(result.totalAmount).toBe(2500);
+      expect(result.topTippers).toHaveLength(2);
+    });
+  });
+
+  describe('exportReport', () => {
+    it('should export tips report in JSON format', async () => {
+      const mockQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { timestamp: new Date(), tipCount: '10', totalAmount: '500', uniqueTippers: '5' },
+      ]);
+
+      const result = await service.exportReport('tips', { period: AnalyticsPeriod.WEEK }, 'json');
+
+      expect(result.format).toBe('json');
+      expect(result.data).toBeDefined();
+      expect(result.filename).toContain('tip-trends');
+    });
+
+    it('should export artist rankings in CSV format', async () => {
+      const mockQueryBuilder = mockArtistRepository.createQueryBuilder();
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        {
+          artistId: 'artist-1',
+          artistName: 'Artist One',
+          totalAmount: '1000',
+          totalTips: '20',
+        },
+      ]);
+
+      const result = await service.exportReport('artists', { period: AnalyticsPeriod.WEEK }, 'csv');
+
+      expect(result.format).toBe('csv');
+      expect(typeof result.data).toBe('string');
+      expect(result.filename).toContain('artist-rankings');
+    });
+  });
+
+  describe('invalidateCache', () => {
+    it('should invalidate cache keys matching pattern', async () => {
+      mockRedisClient.keys.mockResolvedValue(['analytics:summary:1', 'analytics:summary:2']);
+
+      await service.invalidateCache('summary');
+
+      expect(mockRedisClient.keys).toHaveBeenCalledWith('analytics:summary:*');
+      expect(mockRedisClient.del).toHaveBeenCalledWith('analytics:summary:1', 'analytics:summary:2');
+    });
+  });
+
+  describe('precomputeAnalytics', () => {
+    it('should precompute analytics for all periods', async () => {
+      const mockQueryBuilder = mockTipRepository.createQueryBuilder();
+      mockQueryBuilder.getRawOne.mockResolvedValue({
+        totalTips: '100',
+        totalAmount: '5000',
+        averageTipAmount: '50',
+        uniqueTippers: '50',
+        uniqueArtists: '20',
+      });
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      const mockArtistQueryBuilder = mockArtistRepository.createQueryBuilder();
+      mockArtistQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      await service.precomputeAnalytics();
+
+      expect(mockRedisClient.setex).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -1,0 +1,570 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, MoreThan, LessThan } from 'typeorm';
+import Redis from 'ioredis';
+import { Tip, TipStatus } from '../tips/entities/tip.entity';
+import { Artist } from '../artists/entities/artist.entity';
+import { Track } from '../tracks/entities/track.entity';
+import { Genre } from '../genres/entities/genre.entity';
+import { REDIS_CLIENT } from '../leaderboards/redis.module';
+import {
+  AnalyticsQueryDto,
+  AnalyticsPeriod,
+  AnalyticsGroupBy,
+  TrendsQueryDto,
+  RankingsQueryDto,
+} from './dto/analytics-query.dto';
+import {
+  TipSummaryDto,
+  TrendsResponseDto,
+  RankingsResponseDto,
+  GenreDistributionResponseDto,
+  ArtistAnalyticsDto,
+  ExportReportDto,
+  TrendDataPoint,
+} from './dto/analytics-response.dto';
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger = new Logger(AnalyticsService.name);
+  private readonly CACHE_TTL = 300; // 5 minutes default
+  private readonly LONG_CACHE_TTL = 3600; // 1 hour for historical data
+
+  constructor(
+    @InjectRepository(Tip)
+    private readonly tipRepository: Repository<Tip>,
+    @InjectRepository(Artist)
+    private readonly artistRepository: Repository<Artist>,
+    @InjectRepository(Track)
+    private readonly trackRepository: Repository<Track>,
+    @InjectRepository(Genre)
+    private readonly genreRepository: Repository<Genre>,
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+  ) {}
+
+  /**
+   * Get date range from period string
+   */
+  private getDateRange(period: AnalyticsPeriod): { start: Date; end: Date } {
+    const end = new Date();
+    const start = new Date();
+
+    switch (period) {
+      case AnalyticsPeriod.DAY:
+        start.setDate(start.getDate() - 1);
+        break;
+      case AnalyticsPeriod.WEEK:
+        start.setDate(start.getDate() - 7);
+        break;
+      case AnalyticsPeriod.MONTH:
+        start.setDate(start.getDate() - 30);
+        break;
+      case AnalyticsPeriod.QUARTER:
+        start.setDate(start.getDate() - 90);
+        break;
+      case AnalyticsPeriod.YEAR:
+        start.setFullYear(start.getFullYear() - 1);
+        break;
+      case AnalyticsPeriod.ALL:
+        start.setFullYear(2020, 0, 1); // Platform launch date
+        break;
+    }
+
+    return { start, end };
+  }
+
+  /**
+   * Get cache key for analytics queries
+   */
+  private getCacheKey(prefix: string, params: any): string {
+    const sortedParams = Object.keys(params)
+      .sort()
+      .map((key) => `${key}:${params[key]}`)
+      .join(':');
+    return `analytics:${prefix}:${sortedParams}`;
+  }
+
+  /**
+   * Get tip summary with caching
+   */
+  async getTipSummary(query: AnalyticsQueryDto): Promise<TipSummaryDto> {
+    const cacheKey = this.getCacheKey('summary', query);
+    
+    // Try cache first
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const { start, end } = query.startDate && query.endDate
+      ? { start: new Date(query.startDate), end: new Date(query.endDate) }
+      : this.getDateRange(query.period || AnalyticsPeriod.WEEK);
+
+    const queryBuilder = this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt BETWEEN :start AND :end', { start, end });
+
+    if (query.artistId) {
+      queryBuilder.andWhere('tip.artistId = :artistId', { artistId: query.artistId });
+    }
+
+    const result = await queryBuilder
+      .select([
+        'COUNT(tip.id) as totalTips',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COALESCE(AVG(tip.amount), 0) as averageTipAmount',
+        'COUNT(DISTINCT tip.senderAddress) as uniqueTippers',
+        'COUNT(DISTINCT tip.artistId) as uniqueArtists',
+      ])
+      .getRawOne();
+
+    const summary: TipSummaryDto = {
+      totalTips: parseInt(result.totalTips || 0),
+      totalAmount: parseFloat(result.totalAmount || 0),
+      averageTipAmount: parseFloat(result.averageTipAmount || 0),
+      uniqueTippers: parseInt(result.uniqueTippers || 0),
+      uniqueArtists: parseInt(result.uniqueArtists || 0),
+      periodStart: start,
+      periodEnd: end,
+    };
+
+    // Cache the result
+    await this.redis.setex(cacheKey, this.CACHE_TTL, JSON.stringify(summary));
+
+    return summary;
+  }
+
+  /**
+   * Get tip trends over time
+   */
+  async getTipTrends(query: TrendsQueryDto): Promise<TrendsResponseDto> {
+    const cacheKey = this.getCacheKey('trends', query);
+    
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const { start, end } = query.startDate && query.endDate
+      ? { start: new Date(query.startDate), end: new Date(query.endDate) }
+      : this.getDateRange(query.period || AnalyticsPeriod.WEEK);
+
+    const groupBy = query.groupBy || 'day';
+    
+    // Determine date truncation format based on groupBy
+    let dateTrunc: string;
+    switch (groupBy) {
+      case 'hour':
+        dateTrunc = 'hour';
+        break;
+      case 'week':
+        dateTrunc = 'week';
+        break;
+      case 'month':
+        dateTrunc = 'month';
+        break;
+      default:
+        dateTrunc = 'day';
+    }
+
+    const queryBuilder = this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt BETWEEN :start AND :end', { start, end });
+
+    if (query.artistId) {
+      queryBuilder.andWhere('tip.artistId = :artistId', { artistId: query.artistId });
+    }
+
+    const results = await queryBuilder
+      .select([
+        `DATE_TRUNC('${dateTrunc}', tip.createdAt) as timestamp`,
+        'COUNT(tip.id) as tipCount',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COUNT(DISTINCT tip.senderAddress) as uniqueTippers',
+      ])
+      .groupBy(`DATE_TRUNC('${dateTrunc}', tip.createdAt)`)
+      .orderBy('timestamp', 'ASC')
+      .getRawMany();
+
+    const data: TrendDataPoint[] = results.map((row) => ({
+      timestamp: new Date(row.timestamp),
+      tipCount: parseInt(row.tipCount || 0),
+      totalAmount: parseFloat(row.totalAmount || 0),
+      uniqueTippers: parseInt(row.uniqueTippers || 0),
+    }));
+
+    // Calculate summary stats
+    const totalTips = data.reduce((sum, d) => sum + d.tipCount, 0);
+    const totalAmount = data.reduce((sum, d) => sum + d.totalAmount, 0);
+    
+    // Calculate growth rate (compare first half to second half)
+    const midPoint = Math.floor(data.length / 2);
+    const firstHalf = data.slice(0, midPoint);
+    const secondHalf = data.slice(midPoint);
+    const firstHalfAmount = firstHalf.reduce((sum, d) => sum + d.totalAmount, 0);
+    const secondHalfAmount = secondHalf.reduce((sum, d) => sum + d.totalAmount, 0);
+    const growthRate = firstHalfAmount > 0 
+      ? ((secondHalfAmount - firstHalfAmount) / firstHalfAmount) * 100 
+      : 0;
+
+    const response: TrendsResponseDto = {
+      data,
+      period: query.period || AnalyticsPeriod.WEEK,
+      groupBy,
+      summary: {
+        totalTips,
+        totalAmount,
+        growthRate: Math.round(growthRate * 100) / 100,
+      },
+    };
+
+    await this.redis.setex(cacheKey, this.CACHE_TTL, JSON.stringify(response));
+
+    return response;
+  }
+
+  /**
+   * Get artist rankings
+   */
+  async getArtistRankings(query: RankingsQueryDto): Promise<RankingsResponseDto> {
+    const cacheKey = this.getCacheKey('rankings', query);
+    
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const { start, end } = this.getDateRange(query.period || AnalyticsPeriod.WEEK);
+
+    const queryBuilder = this.artistRepository
+      .createQueryBuilder('artist')
+      .leftJoin('artist.tips', 'tip', 'tip.status = :status AND tip.createdAt BETWEEN :start AND :end', {
+        status: TipStatus.VERIFIED,
+        start,
+        end,
+      })
+      .leftJoin('artist.user', 'user');
+
+    if (query.genre) {
+      queryBuilder.andWhere('artist.genre = :genre', { genre: query.genre });
+    }
+
+    const results = await queryBuilder
+      .select([
+        'artist.id as artistId',
+        'artist.artistName as artistName',
+        'artist.profileImage as profileImage',
+        'artist.genre as genre',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COUNT(tip.id) as totalTips',
+        'COALESCE(AVG(tip.amount), 0) as averageTipAmount',
+        'COUNT(DISTINCT tip.senderAddress) as uniqueTippers',
+      ])
+      .groupBy('artist.id')
+      .addGroupBy('artist.artistName')
+      .addGroupBy('artist.profileImage')
+      .addGroupBy('artist.genre')
+      .orderBy('totalAmount', 'DESC')
+      .limit(query.limit || 50)
+      .offset(query.offset || 0)
+      .getRawMany();
+
+    const rankings = results.map((result, index) => ({
+      artistId: result.artistId,
+      artistName: result.artistName,
+      profileImage: result.profileImage,
+      genre: result.genre,
+      rank: (query.offset || 0) + index + 1,
+      totalTips: parseInt(result.totalTips || 0),
+      totalAmount: parseFloat(result.totalAmount || 0),
+      averageTipAmount: parseFloat(result.averageTipAmount || 0),
+      uniqueTippers: parseInt(result.uniqueTippers || 0),
+    }));
+
+    const response: RankingsResponseDto = {
+      rankings,
+      period: query.period || AnalyticsPeriod.WEEK,
+      total: rankings.length,
+      updatedAt: new Date(),
+    };
+
+    await this.redis.setex(cacheKey, this.LONG_CACHE_TTL, JSON.stringify(response));
+
+    return response;
+  }
+
+  /**
+   * Get genre distribution
+   */
+  async getGenreDistribution(query: AnalyticsQueryDto): Promise<GenreDistributionResponseDto> {
+    const cacheKey = this.getCacheKey('genre-distribution', query);
+    
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const { start, end } = this.getDateRange(query.period || AnalyticsPeriod.WEEK);
+
+    const results = await this.tipRepository
+      .createQueryBuilder('tip')
+      .innerJoin('tip.artist', 'artist')
+      .where('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt BETWEEN :start AND :end', { start, end })
+      .select([
+        'COALESCE(artist.genre, \'Unknown\') as genre',
+        'COUNT(tip.id) as tipCount',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COUNT(DISTINCT artist.id) as artistCount',
+      ])
+      .groupBy('artist.genre')
+      .orderBy('totalAmount', 'DESC')
+      .getRawMany();
+
+    const totalAmount = results.reduce((sum, r) => sum + parseFloat(r.totalAmount || 0), 0);
+
+    const distribution = results.map((result) => ({
+      genre: result.genre || 'Unknown',
+      tipCount: parseInt(result.tipCount || 0),
+      totalAmount: parseFloat(result.totalAmount || 0),
+      percentage: totalAmount > 0 
+        ? Math.round((parseFloat(result.totalAmount || 0) / totalAmount) * 10000) / 100 
+        : 0,
+      artistCount: parseInt(result.artistCount || 0),
+    }));
+
+    const response: GenreDistributionResponseDto = {
+      distribution,
+      period: query.period || AnalyticsPeriod.WEEK,
+      totalAmount,
+      updatedAt: new Date(),
+    };
+
+    await this.redis.setex(cacheKey, this.LONG_CACHE_TTL, JSON.stringify(response));
+
+    return response;
+  }
+
+  /**
+   * Get detailed analytics for a specific artist
+   */
+  async getArtistAnalytics(artistId: string): Promise<ArtistAnalyticsDto> {
+    const cacheKey = `analytics:artist:${artistId}`;
+    
+    const cached = await this.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const artist = await this.artistRepository.findOne({
+      where: { id: artistId },
+    });
+
+    if (!artist) {
+      throw new Error('Artist not found');
+    }
+
+    // Get overall stats
+    const stats = await this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.artistId = :artistId', { artistId })
+      .andWhere('tip.status = :status', { status: TipStatus.VERIFIED })
+      .select([
+        'COUNT(tip.id) as totalTips',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COALESCE(AVG(tip.amount), 0) as averageTipAmount',
+        'COUNT(DISTINCT tip.senderAddress) as uniqueTippers',
+      ])
+      .getRawOne();
+
+    // Get top tippers
+    const topTippers = await this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.artistId = :artistId', { artistId })
+      .andWhere('tip.status = :status', { status: TipStatus.VERIFIED })
+      .select([
+        'tip.senderAddress as userId',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COUNT(tip.id) as tipCount',
+      ])
+      .groupBy('tip.senderAddress')
+      .orderBy('totalAmount', 'DESC')
+      .limit(10)
+      .getRawMany();
+
+    // Get daily trends for last 30 days
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const dailyTrends = await this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.artistId = :artistId', { artistId })
+      .andWhere('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt >= :start', { start: thirtyDaysAgo })
+      .select([
+        "DATE_TRUNC('day', tip.createdAt) as timestamp",
+        'COUNT(tip.id) as tipCount',
+        'COALESCE(SUM(tip.amount), 0) as totalAmount',
+        'COUNT(DISTINCT tip.senderAddress) as uniqueTippers',
+      ])
+      .groupBy("DATE_TRUNC('day', tip.createdAt)")
+      .orderBy('timestamp', 'ASC')
+      .getRawMany();
+
+    // Calculate growth rate
+    const currentMonth = await this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.artistId = :artistId', { artistId })
+      .andWhere('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt >= :start', { start: thirtyDaysAgo })
+      .select('COALESCE(SUM(tip.amount), 0) as amount')
+      .getRawOne();
+
+    const previousMonth = await this.tipRepository
+      .createQueryBuilder('tip')
+      .where('tip.artistId = :artistId', { artistId })
+      .andWhere('tip.status = :status', { status: TipStatus.VERIFIED })
+      .andWhere('tip.createdAt BETWEEN :start AND :end', {
+        start: new Date(thirtyDaysAgo.getTime() - 30 * 24 * 60 * 60 * 1000),
+        end: thirtyDaysAgo,
+      })
+      .select('COALESCE(SUM(tip.amount), 0) as amount')
+      .getRawOne();
+
+    const currentAmount = parseFloat(currentMonth?.amount || 0);
+    const previousAmount = parseFloat(previousMonth?.amount || 0);
+    const growthRate = previousAmount > 0 
+      ? ((currentAmount - previousAmount) / previousAmount) * 100 
+      : 0;
+
+    const analytics: ArtistAnalyticsDto = {
+      artistId,
+      artistName: artist.artistName,
+      totalTips: parseInt(stats.totalTips || 0),
+      totalAmount: parseFloat(stats.totalAmount || 0),
+      averageTipAmount: parseFloat(stats.averageTipAmount || 0),
+      uniqueTippers: parseInt(stats.uniqueTippers || 0),
+      tipGrowthRate: Math.round(growthRate * 100) / 100,
+      topTippers: topTippers.map((t) => ({
+        userId: t.userId,
+        username: `User ${t.userId.slice(0, 8)}`,
+        totalAmount: parseFloat(t.totalAmount || 0),
+        tipCount: parseInt(t.tipCount || 0),
+      })),
+      dailyTrends: dailyTrends.map((d) => ({
+        timestamp: new Date(d.timestamp),
+        tipCount: parseInt(d.tipCount || 0),
+        totalAmount: parseFloat(d.totalAmount || 0),
+        uniqueTippers: parseInt(d.uniqueTippers || 0),
+      })),
+    };
+
+    await this.redis.setex(cacheKey, this.CACHE_TTL, JSON.stringify(analytics));
+
+    return analytics;
+  }
+
+  /**
+   * Export analytics report
+   */
+  async exportReport(
+    type: 'tips' | 'artists' | 'genres',
+    query: AnalyticsQueryDto,
+    format: 'csv' | 'json' | 'xlsx' = 'json',
+  ): Promise<ExportReportDto> {
+    let data: any[] = [];
+    let filename: string;
+
+    const timestamp = new Date().toISOString().split('T')[0];
+
+    switch (type) {
+      case 'tips':
+        const trends = await this.getTipTrends(query);
+        data = trends.data;
+        filename = `tip-trends-${timestamp}.${format}`;
+        break;
+      case 'artists':
+        const rankings = await this.getArtistRankings(query);
+        data = rankings.rankings;
+        filename = `artist-rankings-${timestamp}.${format}`;
+        break;
+      case 'genres':
+        const distribution = await this.getGenreDistribution(query);
+        data = distribution.distribution;
+        filename = `genre-distribution-${timestamp}.${format}`;
+        break;
+    }
+
+    // Format data based on export type
+    let exportData: any[] | string = data;
+    if (format === 'csv') {
+      exportData = this.convertToCSV(data);
+    }
+
+    return {
+      format,
+      data: exportData,
+      filename,
+      generatedAt: new Date(),
+    };
+  }
+
+  /**
+   * Convert data to CSV format
+   */
+  private convertToCSV(data: any[]): string {
+    if (data.length === 0) return '';
+
+    const headers = Object.keys(data[0]);
+    const csvRows = [headers.join(',')];
+
+    for (const row of data) {
+      const values = headers.map((header) => {
+        const value = row[header];
+        if (value === null || value === undefined) return '';
+        if (typeof value === 'string' && value.includes(',')) {
+          return `"${value}"`;
+        }
+        return value;
+      });
+      csvRows.push(values.join(','));
+    }
+
+    return csvRows.join('\n');
+  }
+
+  /**
+   * Invalidate cache for specific analytics
+   */
+  async invalidateCache(pattern: string): Promise<void> {
+    const keys = await this.redis.keys(`analytics:${pattern}:*`);
+    if (keys.length > 0) {
+      await this.redis.del(...keys);
+      this.logger.log(`Invalidated ${keys.length} cache keys for pattern: ${pattern}`);
+    }
+  }
+
+  /**
+   * Pre-compute and cache common analytics
+   */
+  async precomputeAnalytics(): Promise<void> {
+    this.logger.log('Starting analytics pre-computation');
+
+    try {
+      // Pre-compute tip summaries for different periods
+      const periods = [AnalyticsPeriod.DAY, AnalyticsPeriod.WEEK, AnalyticsPeriod.MONTH];
+      for (const period of periods) {
+        await this.getTipSummary({ period });
+        await this.getTipTrends({ period, groupBy: AnalyticsGroupBy.DAY });
+        await this.getArtistRankings({ period, limit: 100 });
+        await this.getGenreDistribution({ period });
+      }
+
+      this.logger.log('Analytics pre-computation completed');
+    } catch (error) {
+      this.logger.error('Error during analytics pre-computation', error);
+    }
+  }
+}

--- a/backend/src/analytics/dto/analytics-query.dto.ts
+++ b/backend/src/analytics/dto/analytics-query.dto.ts
@@ -1,0 +1,83 @@
+import { IsOptional, IsEnum, IsDateString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum AnalyticsPeriod {
+  DAY = '1d',
+  WEEK = '7d',
+  MONTH = '30d',
+  QUARTER = '90d',
+  YEAR = '1y',
+  ALL = 'all',
+}
+
+export enum AnalyticsGroupBy {
+  HOUR = 'hour',
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+}
+
+export class AnalyticsQueryDto {
+  @IsOptional()
+  @IsEnum(AnalyticsPeriod)
+  period?: AnalyticsPeriod = AnalyticsPeriod.WEEK;
+
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @IsOptional()
+  @IsEnum(AnalyticsGroupBy)
+  groupBy?: AnalyticsGroupBy = AnalyticsGroupBy.DAY;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 50;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number = 0;
+
+  @IsOptional()
+  artistId?: string;
+
+  @IsOptional()
+  genre?: string;
+}
+
+export class TrendsQueryDto extends AnalyticsQueryDto {
+  @IsOptional()
+  @IsEnum(AnalyticsPeriod)
+  period?: AnalyticsPeriod = AnalyticsPeriod.WEEK;
+}
+
+export class RankingsQueryDto {
+  @IsOptional()
+  @IsEnum(AnalyticsPeriod)
+  period?: AnalyticsPeriod = AnalyticsPeriod.WEEK;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number = 50;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number = 0;
+
+  @IsOptional()
+  genre?: string;
+}

--- a/backend/src/analytics/dto/analytics-response.dto.ts
+++ b/backend/src/analytics/dto/analytics-response.dto.ts
@@ -1,0 +1,97 @@
+export interface TipSummaryDto {
+  totalTips: number;
+  totalAmount: number;
+  averageTipAmount: number;
+  uniqueTippers: number;
+  uniqueArtists: number;
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+export interface TrendDataPoint {
+  timestamp: Date;
+  tipCount: number;
+  totalAmount: number;
+  uniqueTippers: number;
+}
+
+export interface TrendsResponseDto {
+  data: TrendDataPoint[];
+  period: string;
+  groupBy: string;
+  summary: {
+    totalTips: number;
+    totalAmount: number;
+    growthRate: number;
+  };
+}
+
+export interface ArtistRankingDto {
+  artistId: string;
+  artistName: string;
+  profileImage?: string;
+  rank: number;
+  totalTips: number;
+  totalAmount: number;
+  averageTipAmount: number;
+  uniqueTippers: number;
+  genre?: string;
+}
+
+export interface RankingsResponseDto {
+  rankings: ArtistRankingDto[];
+  period: string;
+  total: number;
+  updatedAt: Date;
+}
+
+export interface GenreDistributionDto {
+  genre: string;
+  tipCount: number;
+  totalAmount: number;
+  percentage: number;
+  artistCount: number;
+}
+
+export interface GenreDistributionResponseDto {
+  distribution: GenreDistributionDto[];
+  period: string;
+  totalAmount: number;
+  updatedAt: Date;
+}
+
+export interface TimeSeriesDataPoint {
+  timestamp: string;
+  value: number;
+  label: string;
+}
+
+export interface TimeSeriesResponseDto {
+  series: TimeSeriesDataPoint[];
+  metric: string;
+  period: string;
+}
+
+export interface ArtistAnalyticsDto {
+  artistId: string;
+  artistName: string;
+  totalTips: number;
+  totalAmount: number;
+  averageTipAmount: number;
+  uniqueTippers: number;
+  tipGrowthRate: number;
+  topTippers: {
+    userId: string;
+    username: string;
+    totalAmount: number;
+    tipCount: number;
+  }[];
+  dailyTrends: TrendDataPoint[];
+}
+
+export interface ExportReportDto {
+  format: 'csv' | 'json' | 'xlsx';
+  data: any[] | string;
+  filename: string;
+  generatedAt: Date;
+}

--- a/backend/src/analytics/index.ts
+++ b/backend/src/analytics/index.ts
@@ -1,0 +1,6 @@
+export * from './analytics.module';
+export * from './analytics.service';
+export * from './analytics.controller';
+export * from './analytics.scheduler';
+export * from './dto/analytics-query.dto';
+export * from './dto/analytics-response.dto';

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { LeaderboardsModule } from './leaderboards/leaderboards.module';
 import { ReportsModule } from './reports/reports.module';
 import { GoalsModule } from './goals/goals.module';
 import { VerificationModule } from './verification/verification.module';
+import { AnalyticsModule } from './analytics/analytics.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { VerificationModule } from './verification/verification.module';
     ReportsModule,
     GoalsModule,
     VerificationModule,
+    AnalyticsModule,
   ],
   controllers: [],
   providers: [],


### PR DESCRIPTION
… insights

- Create AnalyticsService with data aggregation methods
- Implement Redis caching for frequently accessed data
- Add scheduled jobs for pre-computing analytics (hourly, daily, weekly)
- Build REST API endpoints for analytics data:
  - GET /api/analytics/tips/summary
  - GET /api/analytics/tips/trends
  - GET /api/analytics/artists/rankings
  - GET /api/analytics/genres/distribution
  - GET /api/analytics/artists/:id/analytics
  - GET /api/analytics/export/:type
- Support multiple time periods (day, week, month, quarter, year, all)
- Add export functionality (JSON, CSV formats)
- Include comprehensive unit tests
- Optimize performance with caching and pre-computation
closes #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics dashboard with tip summaries, trends, artist rankings, and genre distribution
  * Added artist-specific analytics page displaying top tippers and daily trends
  * Added report export functionality supporting CSV, JSON, and XLSX formats

* **Tests**
  * Added comprehensive unit test coverage for analytics functionality

* **Chores**
  * Implemented scheduled background pre-computation of analytics for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->