### PR TITLE
feat(track-play-count): implement play count tracking service and end…

### DIFF
--- a/backend/src/track-play-count/1700000000000-CreateTrackPlays.ts
+++ b/backend/src/track-play-count/1700000000000-CreateTrackPlays.ts
@@ -1,0 +1,99 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateTrackPlays1700000000000 implements MigrationInterface {
+  name = 'CreateTrackPlays1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create enum type
+    await queryRunner.query(`
+      CREATE TYPE "play_source_enum" AS ENUM (
+        'search', 'playlist', 'artist_profile', 'tip_feed', 'direct'
+      )
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'track_plays',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'track_id', type: 'uuid', isNullable: false },
+          { name: 'user_id', type: 'uuid', isNullable: true },
+          { name: 'session_id', type: 'varchar', length: '128', isNullable: false },
+          { name: 'listen_duration', type: 'integer', isNullable: false },
+          { name: 'completed_full', type: 'boolean', default: false },
+          { name: 'source', type: 'play_source_enum', default: "'direct'" },
+          { name: 'ip_hash', type: 'varchar', length: '64', isNullable: false },
+          { name: 'counted_as_play', type: 'boolean', default: false },
+          {
+            name: 'played_at',
+            type: 'timestamp with time zone',
+            default: 'now()',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['track_id'],
+            referencedTableName: 'tracks',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['user_id'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'SET NULL',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Performance indexes
+    await queryRunner.createIndex(
+      'track_plays',
+      new TableIndex({
+        name: 'IDX_track_plays_track_user_played',
+        columnNames: ['track_id', 'user_id', 'played_at'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'track_plays',
+      new TableIndex({
+        name: 'IDX_track_plays_track_session_played',
+        columnNames: ['track_id', 'session_id', 'played_at'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'track_plays',
+      new TableIndex({
+        name: 'IDX_track_plays_ip_track_played',
+        columnNames: ['ip_hash', 'track_id', 'played_at'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'track_plays',
+      new TableIndex({
+        name: 'IDX_track_plays_counted',
+        columnNames: ['track_id', 'counted_as_play', 'played_at'],
+      }),
+    );
+
+    // Add plays column to tracks if not present
+    await queryRunner.query(`
+      ALTER TABLE tracks
+        ADD COLUMN IF NOT EXISTS plays integer NOT NULL DEFAULT 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('track_plays', true);
+    await queryRunner.query(`DROP TYPE IF EXISTS "play_source_enum"`);
+    await queryRunner.query(`ALTER TABLE tracks DROP COLUMN IF EXISTS plays`);
+  }
+}

--- a/backend/src/track-play-count/play-count-response.dto.ts
+++ b/backend/src/track-play-count/play-count-response.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PlaySource } from '../entities/track-play.entity';
+
+export class RecordPlayResponseDto {
+  @ApiProperty()
+  counted: boolean;
+
+  @ApiProperty()
+  reason: string;
+
+  @ApiPropertyOptional()
+  playId?: string;
+}
+
+export class TrackStatsDto {
+  @ApiProperty()
+  trackId: string;
+
+  @ApiProperty()
+  totalPlays: number;
+
+  @ApiProperty()
+  uniqueListeners: number;
+
+  @ApiProperty()
+  completionRate: number;
+
+  @ApiProperty()
+  skipRate: number;
+
+  @ApiProperty()
+  avgListenDuration: number;
+
+  @ApiProperty()
+  period: string;
+}
+
+export class SourceBreakdownDto {
+  @ApiProperty()
+  trackId: string;
+
+  @ApiProperty({ type: 'object', additionalProperties: { type: 'number' } })
+  sources: Record<PlaySource, number>;
+}
+
+export class ArtistOverviewDto {
+  @ApiProperty()
+  artistId: string;
+
+  @ApiProperty()
+  totalPlays: number;
+
+  @ApiProperty()
+  uniqueListeners: number;
+
+  @ApiProperty()
+  totalTracks: number;
+
+  @ApiProperty()
+  avgCompletionRate: number;
+
+  @ApiProperty()
+  topTracks: TopTrackDto[];
+}
+
+export class TopTrackDto {
+  @ApiProperty()
+  trackId: string;
+
+  @ApiProperty()
+  plays: number;
+
+  @ApiProperty()
+  completionRate: number;
+}
+
+export class TopTracksDto {
+  @ApiProperty()
+  period: string;
+
+  @ApiProperty({ type: [TopTrackDto] })
+  tracks: TopTrackDto[];
+}

--- a/backend/src/track-play-count/play-count.controller.spec.ts
+++ b/backend/src/track-play-count/play-count.controller.spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlayCountController } from './play-count.controller';
+import { PlayCountService } from './play-count.service';
+import { RecordPlayDto } from './dto/record-play.dto';
+import { PlaySource } from './entities/track-play.entity';
+
+const mockService = {
+  recordPlay: jest.fn(),
+  getTrackStats: jest.fn(),
+  getArtistOverview: jest.fn(),
+  getTrackSources: jest.fn(),
+  getTopTracks: jest.fn(),
+};
+
+const mockRequest = (ip = '127.0.0.1', forwardedFor?: string): any => ({
+  headers: forwardedFor ? { 'x-forwarded-for': forwardedFor } : {},
+  socket: { remoteAddress: ip },
+});
+
+describe('PlayCountController', () => {
+  let controller: PlayCountController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PlayCountController],
+      providers: [{ provide: PlayCountService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get(PlayCountController);
+    jest.clearAllMocks();
+  });
+
+  // ─── POST /api/plays/record ─────────────────────────────────────────────
+
+  describe('recordPlay', () => {
+    const dto: RecordPlayDto = {
+      trackId: 'track-uuid',
+      userId: 'user-uuid',
+      sessionId: 'sess-1',
+      listenDuration: 60,
+      completedFull: true,
+      source: PlaySource.SEARCH,
+    };
+
+    it('calls service with dto and extracted IP', async () => {
+      mockService.recordPlay.mockResolvedValue({ counted: true, reason: 'ok' });
+      const req = mockRequest('10.0.0.1');
+
+      await controller.recordPlay(dto, req);
+      expect(mockService.recordPlay).toHaveBeenCalledWith(dto, '10.0.0.1');
+    });
+
+    it('prefers x-forwarded-for header over socket IP', async () => {
+      mockService.recordPlay.mockResolvedValue({ counted: true, reason: 'ok' });
+      const req = mockRequest('10.0.0.1', '203.0.113.1, 10.0.0.1');
+
+      await controller.recordPlay(dto, req);
+      expect(mockService.recordPlay).toHaveBeenCalledWith(dto, '203.0.113.1');
+    });
+
+    it('falls back to 0.0.0.0 if no IP available', async () => {
+      mockService.recordPlay.mockResolvedValue({ counted: true, reason: 'ok' });
+      const req: any = { headers: {}, socket: {} };
+
+      await controller.recordPlay(dto, req);
+      expect(mockService.recordPlay).toHaveBeenCalledWith(dto, '0.0.0.0');
+    });
+
+    it('returns service response', async () => {
+      const serviceResponse = { counted: false, reason: 'duplicate', playId: 'x' };
+      mockService.recordPlay.mockResolvedValue(serviceResponse);
+
+      const result = await controller.recordPlay(dto, mockRequest());
+      expect(result).toEqual(serviceResponse);
+    });
+  });
+
+  // ─── GET /api/plays/track/:trackId/stats ────────────────────────────────
+
+  describe('getTrackStats', () => {
+    it('calls service with correct params', async () => {
+      mockService.getTrackStats.mockResolvedValue({});
+      await controller.getTrackStats('track-uuid', '30d');
+      expect(mockService.getTrackStats).toHaveBeenCalledWith('track-uuid', '30d');
+    });
+
+    it('defaults period to 7d', async () => {
+      mockService.getTrackStats.mockResolvedValue({});
+      await controller.getTrackStats('track-uuid', '7d');
+      expect(mockService.getTrackStats).toHaveBeenCalledWith('track-uuid', '7d');
+    });
+  });
+
+  // ─── GET /api/plays/artist/:artistId/overview ───────────────────────────
+
+  describe('getArtistOverview', () => {
+    it('delegates to service', async () => {
+      const overview = { artistId: 'artist-1', totalPlays: 100 };
+      mockService.getArtistOverview.mockResolvedValue(overview);
+
+      const result = await controller.getArtistOverview('artist-1');
+      expect(result).toEqual(overview);
+      expect(mockService.getArtistOverview).toHaveBeenCalledWith('artist-1');
+    });
+  });
+
+  // ─── GET /api/plays/track/:trackId/sources ──────────────────────────────
+
+  describe('getTrackSources', () => {
+    it('delegates to service', async () => {
+      const sources = { trackId: 'track-1', sources: {} };
+      mockService.getTrackSources.mockResolvedValue(sources);
+
+      const result = await controller.getTrackSources('track-1');
+      expect(result).toEqual(sources);
+    });
+  });
+
+  // ─── GET /api/plays/top-tracks ───────────────────────────────────────────
+
+  describe('getTopTracks', () => {
+    it('passes period and limit to service', async () => {
+      mockService.getTopTracks.mockResolvedValue({ period: '7d', tracks: [] });
+      await controller.getTopTracks('14d', 10);
+      expect(mockService.getTopTracks).toHaveBeenCalledWith('14d', 10);
+    });
+
+    it('defaults to 20 results', async () => {
+      mockService.getTopTracks.mockResolvedValue({ period: '7d', tracks: [] });
+      await controller.getTopTracks('7d', 20);
+      expect(mockService.getTopTracks).toHaveBeenCalledWith('7d', 20);
+    });
+  });
+});

--- a/backend/src/track-play-count/play-count.controller.ts
+++ b/backend/src/track-play-count/play-count.controller.ts
@@ -1,0 +1,96 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  Query,
+  ParseUUIDPipe,
+  Req,
+  HttpCode,
+  HttpStatus,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { PlayCountService } from './play-count.service';
+import { RecordPlayDto } from './dto/record-play.dto';
+import {
+  RecordPlayResponseDto,
+  TrackStatsDto,
+  SourceBreakdownDto,
+  ArtistOverviewDto,
+  TopTracksDto,
+} from './dto/play-count-response.dto';
+
+@ApiTags('plays')
+@Controller('api/plays')
+export class PlayCountController {
+  constructor(private readonly playCountService: PlayCountService) {}
+
+  @Post('record')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Record a track play event' })
+  @ApiResponse({ status: 200, type: RecordPlayResponseDto })
+  async recordPlay(
+    @Body() dto: RecordPlayDto,
+    @Req() req: Request,
+  ): Promise<RecordPlayResponseDto> {
+    const ip =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0].trim() ||
+      req.socket.remoteAddress ||
+      '0.0.0.0';
+    return this.playCountService.recordPlay(dto, ip);
+  }
+
+  @Get('track/:trackId/stats')
+  @ApiOperation({ summary: 'Get streaming stats for a track' })
+  @ApiParam({ name: 'trackId', type: String })
+  @ApiQuery({ name: 'period', required: false, example: '7d' })
+  @ApiResponse({ status: 200, type: TrackStatsDto })
+  async getTrackStats(
+    @Param('trackId', ParseUUIDPipe) trackId: string,
+    @Query('period') period = '7d',
+  ): Promise<TrackStatsDto> {
+    return this.playCountService.getTrackStats(trackId, period);
+  }
+
+  @Get('artist/:artistId/overview')
+  @ApiOperation({ summary: 'Get streaming overview for an artist' })
+  @ApiParam({ name: 'artistId', type: String })
+  @ApiResponse({ status: 200, type: ArtistOverviewDto })
+  async getArtistOverview(
+    @Param('artistId', ParseUUIDPipe) artistId: string,
+  ): Promise<ArtistOverviewDto> {
+    return this.playCountService.getArtistOverview(artistId);
+  }
+
+  @Get('track/:trackId/sources')
+  @ApiOperation({ summary: 'Get source attribution breakdown for a track' })
+  @ApiParam({ name: 'trackId', type: String })
+  @ApiResponse({ status: 200, type: SourceBreakdownDto })
+  async getTrackSources(
+    @Param('trackId', ParseUUIDPipe) trackId: string,
+  ): Promise<SourceBreakdownDto> {
+    return this.playCountService.getTrackSources(trackId);
+  }
+
+  @Get('top-tracks')
+  @ApiOperation({ summary: 'Get top tracks by play count for a period' })
+  @ApiQuery({ name: 'period', required: false, example: '7d' })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  @ApiResponse({ status: 200, type: TopTracksDto })
+  async getTopTracks(
+    @Query('period') period = '7d',
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ): Promise<TopTracksDto> {
+    return this.playCountService.getTopTracks(period, limit);
+  }
+}

--- a/backend/src/track-play-count/play-count.dedup.spec.ts
+++ b/backend/src/track-play-count/play-count.dedup.spec.ts
@@ -1,0 +1,376 @@
+/**
+ * play-count.dedup.spec.ts
+ *
+ * Focused suite for deduplication logic as required by the acceptance criteria.
+ * These tests verify that play count gaming is prevented across all three
+ * deduplication axes: userId, sessionId, and ipHash.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import {
+  PlayCountService,
+  MINIMUM_LISTEN_SECONDS,
+  DEDUP_WINDOW_HOURS,
+} from './play-count.service';
+import { TrackPlay, PlaySource } from './entities/track-play.entity';
+
+const TRACK_ID = 'track-aaa';
+const USER_ID = 'user-bbb';
+const SESSION_ID = 'session-ccc';
+const IP_HASH = 'a'.repeat(64);
+
+const recentPlay = (overrides: Partial<TrackPlay> = {}): TrackPlay =>
+  ({
+    id: 'play-id',
+    trackId: TRACK_ID,
+    userId: USER_ID,
+    sessionId: SESSION_ID,
+    listenDuration: 60,
+    completedFull: false,
+    source: PlaySource.DIRECT,
+    ipHash: IP_HASH,
+    countedAsPlay: true,
+    playedAt: new Date(), // within last hour
+    ...overrides,
+  } as TrackPlay);
+
+describe('PlayCountService — Deduplication', () => {
+  let service: PlayCountService;
+  let repoMock: jest.Mocked<any>;
+  let dataSourceMock: jest.Mocked<any>;
+
+  const txManager = {
+    save: jest.fn(),
+    createQueryBuilder: jest.fn().mockReturnValue({
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
+    }),
+  };
+
+  beforeEach(async () => {
+    repoMock = {
+      create: jest.fn().mockImplementation((d) => ({ ...d, id: 'new-id' })),
+      save: jest.fn().mockResolvedValue(undefined),
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+    dataSourceMock = {
+      transaction: jest.fn().mockImplementation(async (cb) => cb(txManager)),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlayCountService,
+        { provide: getRepositoryToken(TrackPlay), useValue: repoMock },
+        { provide: DataSource, useValue: dataSourceMock },
+      ],
+    }).compile();
+
+    service = module.get(PlayCountService);
+    jest.clearAllMocks();
+    repoMock.create.mockImplementation((d) => ({ ...d, id: 'new-id' }));
+    repoMock.save.mockResolvedValue(undefined);
+    dataSourceMock.transaction.mockImplementation(async (cb) => cb(txManager));
+    txManager.save.mockResolvedValue(undefined);
+  });
+
+  // ─── 30-second minimum ────────────────────────────────────────────────────
+
+  describe('30-second minimum enforcement', () => {
+    it.each([0, 1, 10, 15, 29])(
+      'does NOT count a %ds play',
+      async (duration) => {
+        const result = await service.recordPlay(
+          {
+            trackId: TRACK_ID,
+            userId: USER_ID,
+            sessionId: SESSION_ID,
+            listenDuration: duration,
+            completedFull: false,
+            source: PlaySource.DIRECT,
+          },
+          '1.2.3.4',
+        );
+        expect(result.counted).toBe(false);
+        expect(dataSourceMock.transaction).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([30, 31, 60, 180, 300])(
+      'COUNTS a %ds play when not a duplicate',
+      async (duration) => {
+        repoMock.findOne.mockResolvedValue(null);
+        const result = await service.recordPlay(
+          {
+            trackId: TRACK_ID,
+            userId: USER_ID,
+            sessionId: SESSION_ID,
+            listenDuration: duration,
+            completedFull: false,
+            source: PlaySource.DIRECT,
+          },
+          '1.2.3.4',
+        );
+        expect(result.counted).toBe(true);
+      },
+    );
+  });
+
+  // ─── userId deduplication ─────────────────────────────────────────────────
+
+  describe('userId-based deduplication', () => {
+    it('blocks re-count when same user replays within 1 hour', async () => {
+      repoMock.findOne.mockResolvedValueOnce(recentPlay()); // userId match
+
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: 'different-session',
+          listenDuration: 60,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '9.9.9.9',
+      );
+
+      expect(result.counted).toBe(false);
+      expect(result.reason).toMatch(/duplicate/i);
+    });
+
+    it('allows re-count for different user', async () => {
+      repoMock.findOne.mockResolvedValue(null);
+
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: 'different-user-id',
+          sessionId: SESSION_ID,
+          listenDuration: 60,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '1.2.3.4',
+      );
+
+      expect(result.counted).toBe(true);
+    });
+  });
+
+  // ─── sessionId deduplication ─────────────────────────────────────────────
+
+  describe('sessionId-based deduplication (anonymous users)', () => {
+    it('blocks re-count when same session replays within 1 hour', async () => {
+      // No userId provided, session match
+      repoMock.findOne
+        .mockResolvedValueOnce(null)      // userId skipped (null → skips first call)
+        .mockResolvedValueOnce(recentPlay()); // session match
+
+      const result = await service.isDuplicate(TRACK_ID, null, SESSION_ID, IP_HASH);
+      expect(result).toBe(true);
+    });
+
+    it('counts anonymous play when no session match', async () => {
+      repoMock.findOne.mockResolvedValue(null);
+
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          sessionId: 'brand-new-session',
+          listenDuration: 60,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '5.5.5.5',
+      );
+
+      expect(result.counted).toBe(true);
+    });
+
+    it('deduplicates across session even for authenticated users', async () => {
+      repoMock.findOne
+        .mockResolvedValueOnce(null)       // userId miss
+        .mockResolvedValueOnce(recentPlay()); // session hit
+
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 45,
+          completedFull: false,
+          source: PlaySource.SEARCH,
+        },
+        '2.2.2.2',
+      );
+
+      expect(result.counted).toBe(false);
+    });
+  });
+
+  // ─── IP-hash deduplication ────────────────────────────────────────────────
+
+  describe('ipHash-based deduplication', () => {
+    it('blocks re-count when same IP replays even with new session', async () => {
+      repoMock.findOne
+        .mockResolvedValueOnce(null) // userId miss
+        .mockResolvedValueOnce(null) // sessionId miss
+        .mockResolvedValueOnce(recentPlay()); // ip match
+
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: 'fresh-session',
+          listenDuration: 60,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '1.2.3.4',
+      );
+
+      expect(result.counted).toBe(false);
+    });
+  });
+
+  // ─── Dedup window boundary ────────────────────────────────────────────────
+
+  describe('1-hour deduplication window', () => {
+    it('isDuplicate queries with MoreThan timestamp approximately 1 hour ago', async () => {
+      const beforeCall = Date.now();
+      repoMock.findOne.mockResolvedValue(null);
+
+      await service.isDuplicate(TRACK_ID, USER_ID, SESSION_ID, IP_HASH);
+
+      const call = repoMock.findOne.mock.calls[0][0];
+      const windowStart: Date = call.where.playedAt.value;
+
+      const expectedMs = DEDUP_WINDOW_HOURS * 60 * 60 * 1000;
+      const actualDiff = beforeCall - windowStart.getTime();
+
+      // Allow ±2 seconds tolerance
+      expect(actualDiff).toBeGreaterThanOrEqual(expectedMs - 2000);
+      expect(actualDiff).toBeLessThanOrEqual(expectedMs + 2000);
+    });
+
+    it('does not block plays when the duplicate is outside the 1-hour window', async () => {
+      // Simulates: existing play was >1h ago → should NOT block
+      repoMock.findOne.mockResolvedValue(null); // findOne returns null = no recent dup
+
+      const result = await service.isDuplicate(TRACK_ID, USER_ID, SESSION_ID, IP_HASH);
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── countedAsPlay flag ───────────────────────────────────────────────────
+
+  describe('countedAsPlay integrity', () => {
+    it('only queries for plays where countedAsPlay = true in dedup check', async () => {
+      repoMock.findOne.mockResolvedValue(null);
+      await service.isDuplicate(TRACK_ID, USER_ID, SESSION_ID, IP_HASH);
+
+      repoMock.findOne.mock.calls.forEach((call) => {
+        expect(call[0].where.countedAsPlay).toBe(true);
+      });
+    });
+
+    it('persists raw skipped events with countedAsPlay = false', async () => {
+      const result = await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 5, // skip
+          completedFull: false,
+          source: PlaySource.TIP_FEED,
+        },
+        '3.3.3.3',
+      );
+
+      expect(result.counted).toBe(false);
+      expect(repoMock.save).toHaveBeenCalledWith(
+        expect.objectContaining({ countedAsPlay: false }),
+      );
+    });
+
+    it('persists duplicate raw events with countedAsPlay = false', async () => {
+      repoMock.findOne.mockResolvedValueOnce(recentPlay());
+
+      await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 60,
+          completedFull: true,
+          source: PlaySource.PLAYLIST,
+        },
+        '4.4.4.4',
+      );
+
+      expect(repoMock.save).toHaveBeenCalledWith(
+        expect.objectContaining({ countedAsPlay: false }),
+      );
+    });
+  });
+
+  // ─── Track.plays increment ───────────────────────────────────────────────
+
+  describe('Track.plays update', () => {
+    it('increments Track.plays inside a transaction on genuine play', async () => {
+      repoMock.findOne.mockResolvedValue(null);
+
+      await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 90,
+          completedFull: true,
+          source: PlaySource.ARTIST_PROFILE,
+        },
+        '6.7.8.9',
+      );
+
+      expect(dataSourceMock.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT increment Track.plays for skipped plays', async () => {
+      await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 10,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '1.1.1.1',
+      );
+
+      expect(dataSourceMock.transaction).not.toHaveBeenCalled();
+    });
+
+    it('does NOT increment Track.plays for duplicate plays', async () => {
+      repoMock.findOne.mockResolvedValueOnce(recentPlay());
+
+      await service.recordPlay(
+        {
+          trackId: TRACK_ID,
+          userId: USER_ID,
+          sessionId: SESSION_ID,
+          listenDuration: 60,
+          completedFull: false,
+          source: PlaySource.DIRECT,
+        },
+        '1.1.1.1',
+      );
+
+      expect(dataSourceMock.transaction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/track-play-count/play-count.e2e-spec.ts
+++ b/backend/src/track-play-count/play-count.e2e-spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { PlayCountModule } from './play-count.module';
+import { PlayCountService } from './play-count.service';
+import { PlaySource } from './entities/track-play.entity';
+
+const UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('PlayCount (e2e)', () => {
+  let app: INestApplication;
+  const serviceMock = {
+    recordPlay: jest.fn(),
+    getTrackStats: jest.fn(),
+    getArtistOverview: jest.fn(),
+    getTrackSources: jest.fn(),
+    getTopTracks: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PlayCountModule],
+    })
+      .overrideProvider(PlayCountService)
+      .useValue(serviceMock)
+      .compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('POST /api/plays/record', () => {
+    const validBody = {
+      trackId: UUID,
+      userId: UUID,
+      sessionId: 'session-xyz',
+      listenDuration: 60,
+      completedFull: true,
+      source: PlaySource.SEARCH,
+    };
+
+    it('returns 200 with a valid body', async () => {
+      serviceMock.recordPlay.mockResolvedValue({ counted: true, reason: 'ok', playId: UUID });
+
+      return request(app.getHttpServer())
+        .post('/api/plays/record')
+        .send(validBody)
+        .expect(200)
+        .expect({ counted: true, reason: 'ok', playId: UUID });
+    });
+
+    it('returns 400 for missing required fields', () => {
+      return request(app.getHttpServer())
+        .post('/api/plays/record')
+        .send({ trackId: UUID }) // missing many fields
+        .expect(400);
+    });
+
+    it('returns 400 for invalid trackId (not UUID)', () => {
+      return request(app.getHttpServer())
+        .post('/api/plays/record')
+        .send({ ...validBody, trackId: 'not-a-uuid' })
+        .expect(400);
+    });
+
+    it('returns 400 for invalid source enum', () => {
+      return request(app.getHttpServer())
+        .post('/api/plays/record')
+        .send({ ...validBody, source: 'invalid_source' })
+        .expect(400);
+    });
+
+    it('returns 400 for negative listenDuration', () => {
+      return request(app.getHttpServer())
+        .post('/api/plays/record')
+        .send({ ...validBody, listenDuration: -1 })
+        .expect(400);
+    });
+  });
+
+  describe('GET /api/plays/track/:trackId/stats', () => {
+    it('returns 200 for valid UUID', async () => {
+      serviceMock.getTrackStats.mockResolvedValue({ trackId: UUID, totalPlays: 5 });
+
+      return request(app.getHttpServer())
+        .get(`/api/plays/track/${UUID}/stats`)
+        .expect(200);
+    });
+
+    it('passes period query param', async () => {
+      serviceMock.getTrackStats.mockResolvedValue({});
+
+      await request(app.getHttpServer())
+        .get(`/api/plays/track/${UUID}/stats?period=30d`)
+        .expect(200);
+
+      expect(serviceMock.getTrackStats).toHaveBeenCalledWith(UUID, '30d');
+    });
+
+    it('returns 400 for invalid UUID', () => {
+      return request(app.getHttpServer())
+        .get('/api/plays/track/not-a-uuid/stats')
+        .expect(400);
+    });
+  });
+
+  describe('GET /api/plays/artist/:artistId/overview', () => {
+    it('returns 200 for valid UUID', async () => {
+      serviceMock.getArtistOverview.mockResolvedValue({ artistId: UUID });
+
+      return request(app.getHttpServer())
+        .get(`/api/plays/artist/${UUID}/overview`)
+        .expect(200);
+    });
+  });
+
+  describe('GET /api/plays/track/:trackId/sources', () => {
+    it('returns 200 for valid UUID', async () => {
+      serviceMock.getTrackSources.mockResolvedValue({ trackId: UUID, sources: {} });
+
+      return request(app.getHttpServer())
+        .get(`/api/plays/track/${UUID}/sources`)
+        .expect(200);
+    });
+  });
+
+  describe('GET /api/plays/top-tracks', () => {
+    it('returns 200', async () => {
+      serviceMock.getTopTracks.mockResolvedValue({ period: '7d', tracks: [] });
+
+      return request(app.getHttpServer())
+        .get('/api/plays/top-tracks')
+        .expect(200);
+    });
+
+    it('passes period and limit params', async () => {
+      serviceMock.getTopTracks.mockResolvedValue({ period: '14d', tracks: [] });
+
+      await request(app.getHttpServer())
+        .get('/api/plays/top-tracks?period=14d&limit=5')
+        .expect(200);
+
+      expect(serviceMock.getTopTracks).toHaveBeenCalledWith('14d', 5);
+    });
+  });
+});

--- a/backend/src/track-play-count/play-count.module.ts
+++ b/backend/src/track-play-count/play-count.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TrackPlay } from './entities/track-play.entity';
+import { PlayCountService } from './play-count.service';
+import { PlayCountController } from './play-count.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TrackPlay])],
+  controllers: [PlayCountController],
+  providers: [PlayCountService],
+  exports: [PlayCountService],
+})
+export class PlayCountModule {}

--- a/backend/src/track-play-count/play-count.service.spec.ts
+++ b/backend/src/track-play-count/play-count.service.spec.ts
@@ -1,0 +1,446 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, MoreThan } from 'typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { PlayCountService, MINIMUM_LISTEN_SECONDS, DEDUP_WINDOW_HOURS } from './play-count.service';
+import { TrackPlay, PlaySource } from './entities/track-play.entity';
+import { RecordPlayDto } from './dto/record-play.dto';
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+const makeDto = (overrides: Partial<RecordPlayDto> = {}): RecordPlayDto => ({
+  trackId: 'track-uuid-1',
+  userId: 'user-uuid-1',
+  sessionId: 'session-abc',
+  listenDuration: 45,
+  completedFull: false,
+  source: PlaySource.DIRECT,
+  ...overrides,
+});
+
+const makePlay = (overrides: Partial<TrackPlay> = {}): TrackPlay =>
+  ({
+    id: 'play-uuid-1',
+    trackId: 'track-uuid-1',
+    userId: 'user-uuid-1',
+    sessionId: 'session-abc',
+    listenDuration: 45,
+    completedFull: false,
+    source: PlaySource.DIRECT,
+    ipHash: 'hashed',
+    countedAsPlay: true,
+    playedAt: new Date(),
+    ...overrides,
+  } as TrackPlay);
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+const mockQbChain = (overrides: Record<string, any> = {}) => {
+  const qb: any = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    clone: jest.fn().mockReturnThis(),
+    getCount: jest.fn().mockResolvedValue(0),
+    getRawOne: jest.fn().mockResolvedValue({ avg: '0', cnt: '0' }),
+    getRawMany: jest.fn().mockResolvedValue([]),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return qb;
+};
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('PlayCountService', () => {
+  let service: PlayCountService;
+  let trackPlayRepo: jest.Mocked<any>;
+  let dataSource: jest.Mocked<any>;
+
+  beforeEach(async () => {
+    const repoMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const dataSourceMock = {
+      transaction: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlayCountService,
+        { provide: getRepositoryToken(TrackPlay), useValue: repoMock },
+        { provide: DataSource, useValue: dataSourceMock },
+      ],
+    }).compile();
+
+    service = module.get(PlayCountService);
+    trackPlayRepo = module.get(getRepositoryToken(TrackPlay));
+    dataSource = module.get(DataSource);
+  });
+
+  // ─── hashIp ──────────────────────────────────────────────────────────────
+
+  describe('hashIp', () => {
+    it('returns a 64-char hex string', () => {
+      const hash = service.hashIp('127.0.0.1');
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('produces the same hash for the same IP', () => {
+      expect(service.hashIp('192.168.1.1')).toBe(service.hashIp('192.168.1.1'));
+    });
+
+    it('produces different hashes for different IPs', () => {
+      expect(service.hashIp('1.1.1.1')).not.toBe(service.hashIp('8.8.8.8'));
+    });
+  });
+
+  // ─── isDuplicate ─────────────────────────────────────────────────────────
+
+  describe('isDuplicate', () => {
+    it('returns false when no matching record exists', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const result = await service.isDuplicate('track-1', 'user-1', 'sess-1', 'ip-1');
+      expect(result).toBe(false);
+    });
+
+    it('returns true when userId matches a recent counted play', async () => {
+      trackPlayRepo.findOne.mockResolvedValueOnce(makePlay()); // userId hit
+      const result = await service.isDuplicate('track-1', 'user-1', 'sess-1', 'ip-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns true when sessionId matches even for anonymous user', async () => {
+      trackPlayRepo.findOne
+        .mockResolvedValueOnce(null) // userId check skipped (null)
+        .mockResolvedValueOnce(makePlay()); // session hit
+      const result = await service.isDuplicate('track-1', null, 'sess-1', 'ip-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns true when ipHash matches a recent counted play', async () => {
+      trackPlayRepo.findOne
+        .mockResolvedValueOnce(null) // userId
+        .mockResolvedValueOnce(null) // sessionId
+        .mockResolvedValueOnce(makePlay()); // ip hit
+      const result = await service.isDuplicate('track-1', 'user-1', 'sess-1', 'ip-1');
+      expect(result).toBe(true);
+    });
+
+    it('skips userId check when userId is null', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      await service.isDuplicate('track-1', null, 'sess-1', 'ip-1');
+      // Should only call findOne twice (session + ip), not three times
+      expect(trackPlayRepo.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('queries within the dedup window (1 hour)', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      await service.isDuplicate('track-1', 'user-1', 'sess-1', 'ip-1');
+      const call = trackPlayRepo.findOne.mock.calls[0][0];
+      expect(call.where.playedAt).toBeDefined();
+      // The MoreThan value should be approximately 1 hour ago
+    });
+  });
+
+  // ─── recordPlay ──────────────────────────────────────────────────────────
+
+  describe('recordPlay', () => {
+    const ip = '203.0.113.1';
+
+    beforeEach(() => {
+      trackPlayRepo.create.mockImplementation((data) => ({ ...data, id: 'new-play-id' }));
+      trackPlayRepo.save.mockResolvedValue(undefined);
+      dataSource.transaction.mockImplementation(async (cb) => cb({ save: jest.fn(), createQueryBuilder: jest.fn().mockReturnValue(mockQbChain()) }));
+    });
+
+    it('rejects plays under 30 seconds without counting', async () => {
+      const dto = makeDto({ listenDuration: 29 });
+      const result = await service.recordPlay(dto, ip);
+
+      expect(result.counted).toBe(false);
+      expect(result.reason).toContain('30-second minimum');
+      expect(trackPlayRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ countedAsPlay: false }),
+      );
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('counts plays exactly at 30 seconds', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto = makeDto({ listenDuration: MINIMUM_LISTEN_SECONDS });
+      const result = await service.recordPlay(dto, ip);
+
+      expect(result.counted).toBe(true);
+      expect(dataSource.transaction).toHaveBeenCalled();
+    });
+
+    it('counts plays above 30 seconds', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto = makeDto({ listenDuration: 180 });
+      const result = await service.recordPlay(dto, ip);
+
+      expect(result.counted).toBe(true);
+    });
+
+    it('rejects duplicate plays within dedup window', async () => {
+      // First findOne (userId) returns a recent play
+      trackPlayRepo.findOne.mockResolvedValueOnce(makePlay({ countedAsPlay: true }));
+      const dto = makeDto();
+      const result = await service.recordPlay(dto, ip);
+
+      expect(result.counted).toBe(false);
+      expect(result.reason).toContain('Duplicate');
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('saves a raw event record even for skipped (< 30s) plays', async () => {
+      const dto = makeDto({ listenDuration: 10 });
+      await service.recordPlay(dto, ip);
+      expect(trackPlayRepo.save).toHaveBeenCalled();
+    });
+
+    it('saves a raw event record even for duplicate plays', async () => {
+      trackPlayRepo.findOne.mockResolvedValueOnce(makePlay());
+      const dto = makeDto();
+      await service.recordPlay(dto, ip);
+      expect(trackPlayRepo.save).toHaveBeenCalled();
+    });
+
+    it('sets countedAsPlay=true only for genuine plays', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto = makeDto({ listenDuration: 60 });
+
+      let savedPlay: Partial<TrackPlay> | undefined;
+      dataSource.transaction.mockImplementation(async (cb) => {
+        const manager = {
+          save: jest.fn().mockImplementation((_, play) => { savedPlay = play; }),
+          createQueryBuilder: jest.fn().mockReturnValue(mockQbChain()),
+        };
+        await cb(manager);
+      });
+
+      await service.recordPlay(dto, ip);
+      expect(savedPlay?.countedAsPlay).toBe(true);
+    });
+
+    it('hashes the IP before storing', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto = makeDto({ listenDuration: 60 });
+
+      let createdPlay: Partial<TrackPlay> | undefined;
+      trackPlayRepo.create.mockImplementation((data) => {
+        createdPlay = data;
+        return { ...data, id: 'id' };
+      });
+
+      await service.recordPlay(dto, ip);
+      expect(createdPlay?.ipHash).not.toBe(ip);
+      expect(createdPlay?.ipHash).toHaveLength(64);
+    });
+
+    it('returns playId in all response paths', async () => {
+      // Path 1: under minimum
+      const dto1 = makeDto({ listenDuration: 5 });
+      const r1 = await service.recordPlay(dto1, ip);
+      expect(r1.playId).toBeDefined();
+
+      // Path 2: duplicate
+      trackPlayRepo.findOne.mockResolvedValueOnce(makePlay());
+      const dto2 = makeDto({ listenDuration: 60 });
+      const r2 = await service.recordPlay(dto2, ip);
+      expect(r2.playId).toBeDefined();
+
+      // Path 3: counted
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto3 = makeDto({ listenDuration: 60 });
+      const r3 = await service.recordPlay(dto3, ip);
+      expect(r3.playId).toBeDefined();
+    });
+
+    it('handles anonymous users (no userId)', async () => {
+      trackPlayRepo.findOne.mockResolvedValue(null);
+      const dto = makeDto({ userId: undefined, listenDuration: 60 });
+      const result = await service.recordPlay(dto, ip);
+      expect(result.counted).toBe(true);
+    });
+  });
+
+  // ─── periodToDate ────────────────────────────────────────────────────────
+
+  describe('periodToDate', () => {
+    it('parses days correctly', () => {
+      const now = Date.now();
+      const result = service.periodToDate('7d');
+      const diff = now - result.getTime();
+      expect(diff).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 1000);
+      expect(diff).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 1000);
+    });
+
+    it('parses weeks correctly', () => {
+      const result = service.periodToDate('2w');
+      const diff = Date.now() - result.getTime();
+      expect(diff).toBeGreaterThan(14 * 24 * 60 * 60 * 1000 - 1000);
+    });
+
+    it('parses months correctly', () => {
+      const result = service.periodToDate('1m');
+      // approximately 30 days ago
+      const diff = Date.now() - result.getTime();
+      expect(diff).toBeGreaterThan(28 * 24 * 60 * 60 * 1000);
+    });
+
+    it('throws BadRequestException for invalid format', () => {
+      expect(() => service.periodToDate('invalid')).toThrow(BadRequestException);
+      expect(() => service.periodToDate('abc')).toThrow(BadRequestException);
+      expect(() => service.periodToDate('')).toThrow(BadRequestException);
+    });
+
+    it('throws for unsupported unit', () => {
+      // 'y' (year) is not supported
+      expect(() => service.periodToDate('1y')).toThrow(BadRequestException);
+    });
+  });
+
+  // ─── getTrackStats ────────────────────────────────────────────────────────
+
+  describe('getTrackStats', () => {
+    it('returns correct stats with zero plays', async () => {
+      const qb = mockQbChain({
+        getCount: jest.fn().mockResolvedValue(0),
+        getRawOne: jest.fn().mockResolvedValue({ avg: '0', cnt: '0' }),
+        clone: jest.fn(),
+      });
+      qb.clone.mockReturnValue(qb);
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const stats = await service.getTrackStats('track-1', '7d');
+
+      expect(stats.trackId).toBe('track-1');
+      expect(stats.totalPlays).toBe(0);
+      expect(stats.skipRate).toBe(0);
+      expect(stats.completionRate).toBe(0);
+    });
+
+    it('calculates skip rate correctly', async () => {
+      // totalEvents=10, totalPlays(counted)=6 → skipRate=0.4
+      let callCount = 0;
+      const qb = mockQbChain();
+      qb.clone.mockReturnValue(qb);
+      qb.getCount
+        .mockResolvedValueOnce(6)  // totalPlays (counted)
+        .mockResolvedValueOnce(10) // totalEvents
+        .mockResolvedValueOnce(3); // completedCount
+      qb.getRawOne
+        .mockResolvedValueOnce({ avg: '42.5' }) // avgDuration
+        .mockResolvedValueOnce({ cnt: '5' });   // uniqueListeners
+
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const stats = await service.getTrackStats('track-1', '7d');
+
+      expect(stats.skipRate).toBe(0.4);
+      expect(stats.completionRate).toBe(0.5); // 3/6
+      expect(stats.avgListenDuration).toBe(42.5);
+    });
+
+    it('includes period in response', async () => {
+      const qb = mockQbChain();
+      qb.clone.mockReturnValue(qb);
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const stats = await service.getTrackStats('track-1', '30d');
+      expect(stats.period).toBe('30d');
+    });
+  });
+
+  // ─── getTrackSources ─────────────────────────────────────────────────────
+
+  describe('getTrackSources', () => {
+    it('returns zero counts for all sources when no plays exist', async () => {
+      const qb = mockQbChain({ getRawMany: jest.fn().mockResolvedValue([]) });
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTrackSources('track-1');
+      expect(result.trackId).toBe('track-1');
+      Object.values(PlaySource).forEach((s) => {
+        expect(result.sources[s]).toBe(0);
+      });
+    });
+
+    it('maps raw DB results to source breakdown correctly', async () => {
+      const rawRows = [
+        { source: PlaySource.SEARCH, cnt: '12' },
+        { source: PlaySource.PLAYLIST, cnt: '5' },
+      ];
+      const qb = mockQbChain({ getRawMany: jest.fn().mockResolvedValue(rawRows) });
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTrackSources('track-1');
+      expect(result.sources[PlaySource.SEARCH]).toBe(12);
+      expect(result.sources[PlaySource.PLAYLIST]).toBe(5);
+      expect(result.sources[PlaySource.DIRECT]).toBe(0); // default 0
+    });
+  });
+
+  // ─── getTopTracks ─────────────────────────────────────────────────────────
+
+  describe('getTopTracks', () => {
+    it('returns empty tracks array when no data', async () => {
+      const qb = mockQbChain({ getRawMany: jest.fn().mockResolvedValue([]) });
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTopTracks('7d', 10);
+      expect(result.period).toBe('7d');
+      expect(result.tracks).toEqual([]);
+    });
+
+    it('returns mapped tracks ordered by plays', async () => {
+      const rawRows = [
+        { trackId: 'track-a', plays: '100', completionRate: '0.75' },
+        { trackId: 'track-b', plays: '50', completionRate: '0.5' },
+      ];
+      const qb = mockQbChain({ getRawMany: jest.fn().mockResolvedValue(rawRows) });
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getTopTracks('7d', 20);
+      expect(result.tracks[0].trackId).toBe('track-a');
+      expect(result.tracks[0].plays).toBe(100);
+      expect(result.tracks[0].completionRate).toBe(0.75);
+    });
+
+    it('respects the limit parameter', async () => {
+      const qb = mockQbChain({ getRawMany: jest.fn().mockResolvedValue([]) });
+      trackPlayRepo.createQueryBuilder.mockReturnValue(qb);
+
+      await service.getTopTracks('7d', 5);
+      expect(qb.limit).toHaveBeenCalledWith(5);
+    });
+  });
+
+  // ─── Constants ───────────────────────────────────────────────────────────
+
+  describe('module constants', () => {
+    it('exports MINIMUM_LISTEN_SECONDS as 30', () => {
+      expect(MINIMUM_LISTEN_SECONDS).toBe(30);
+    });
+
+    it('exports DEDUP_WINDOW_HOURS as 1', () => {
+      expect(DEDUP_WINDOW_HOURS).toBe(1);
+    });
+  });
+});

--- a/backend/src/track-play-count/play-count.service.ts
+++ b/backend/src/track-play-count/play-count.service.ts
@@ -1,0 +1,340 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, DataSource } from 'typeorm';
+import * as crypto from 'crypto';
+import { TrackPlay, PlaySource } from './entities/track-play.entity';
+import { RecordPlayDto } from './dto/record-play.dto';
+import {
+  RecordPlayResponseDto,
+  TrackStatsDto,
+  SourceBreakdownDto,
+  ArtistOverviewDto,
+  TopTracksDto,
+  TopTrackDto,
+} from './dto/play-count-response.dto';
+
+export const MINIMUM_LISTEN_SECONDS = 30;
+export const DEDUP_WINDOW_HOURS = 1;
+
+@Injectable()
+export class PlayCountService {
+  private readonly logger = new Logger(PlayCountService.name);
+
+  constructor(
+    @InjectRepository(TrackPlay)
+    private readonly trackPlayRepo: Repository<TrackPlay>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ─── Helpers ────────────────────────────────────────────────────────────────
+
+  hashIp(ip: string): string {
+    return crypto.createHash('sha256').update(ip + 'tip-tune-salt').digest('hex');
+  }
+
+  private dedupWindowStart(): Date {
+    const d = new Date();
+    d.setHours(d.getHours() - DEDUP_WINDOW_HOURS);
+    return d;
+  }
+
+  async isDuplicate(
+    trackId: string,
+    userId: string | null,
+    sessionId: string,
+    ipHash: string,
+  ): Promise<boolean> {
+    const since = this.dedupWindowStart();
+
+    // Check by userId if authenticated
+    if (userId) {
+      const existing = await this.trackPlayRepo.findOne({
+        where: {
+          trackId,
+          userId,
+          countedAsPlay: true,
+          playedAt: MoreThan(since),
+        },
+      });
+      if (existing) return true;
+    }
+
+    // Check by sessionId (covers anonymous)
+    const bySession = await this.trackPlayRepo.findOne({
+      where: {
+        trackId,
+        sessionId,
+        countedAsPlay: true,
+        playedAt: MoreThan(since),
+      },
+    });
+    if (bySession) return true;
+
+    // Check by ipHash as last fallback
+    const byIp = await this.trackPlayRepo.findOne({
+      where: {
+        trackId,
+        ipHash,
+        countedAsPlay: true,
+        playedAt: MoreThan(since),
+      },
+    });
+    return !!byIp;
+  }
+
+  // ─── Record Play ─────────────────────────────────────────────────────────────
+
+  async recordPlay(
+    dto: RecordPlayDto,
+    ip: string,
+  ): Promise<RecordPlayResponseDto> {
+    const ipHash = this.hashIp(ip);
+    const meetsMinimum = dto.listenDuration >= MINIMUM_LISTEN_SECONDS;
+
+    // Always persist the raw event regardless of whether it counts
+    const play = this.trackPlayRepo.create({
+      trackId: dto.trackId,
+      userId: dto.userId ?? null,
+      sessionId: dto.sessionId,
+      listenDuration: dto.listenDuration,
+      completedFull: dto.completedFull,
+      source: dto.source,
+      ipHash,
+      countedAsPlay: false,
+    });
+
+    if (!meetsMinimum) {
+      await this.trackPlayRepo.save(play);
+      return {
+        counted: false,
+        reason: `Listen duration ${dto.listenDuration}s is below the 30-second minimum`,
+        playId: play.id,
+      };
+    }
+
+    const duplicate = await this.isDuplicate(
+      dto.trackId,
+      dto.userId ?? null,
+      dto.sessionId,
+      ipHash,
+    );
+
+    if (duplicate) {
+      await this.trackPlayRepo.save(play);
+      return {
+        counted: false,
+        reason: 'Duplicate play detected within the 1-hour deduplication window',
+        playId: play.id,
+      };
+    }
+
+    // Mark as a genuine counted play and update Track.plays atomically
+    play.countedAsPlay = true;
+    await this.dataSource.transaction(async (manager) => {
+      await manager.save(TrackPlay, play);
+      await manager
+        .createQueryBuilder()
+        .update('tracks')
+        .set({ plays: () => 'plays + 1' })
+        .where('id = :id', { id: dto.trackId })
+        .execute();
+    });
+
+    this.logger.log(`Counted play for track ${dto.trackId} by ${dto.userId ?? dto.sessionId}`);
+
+    return {
+      counted: true,
+      reason: 'Play recorded successfully',
+      playId: play.id,
+    };
+  }
+
+  // ─── Track Stats ─────────────────────────────────────────────────────────────
+
+  async getTrackStats(trackId: string, period = '7d'): Promise<TrackStatsDto> {
+    const since = this.periodToDate(period);
+
+    const qb = this.trackPlayRepo
+      .createQueryBuilder('p')
+      .where('p.track_id = :trackId', { trackId })
+      .andWhere('p.played_at >= :since', { since });
+
+    const [totalPlays, totalEvents, avgDuration, completedCount] =
+      await Promise.all([
+        qb.clone().andWhere('p.counted_as_play = true').getCount(),
+        qb.clone().getCount(),
+        qb
+          .clone()
+          .select('COALESCE(AVG(p.listen_duration), 0)', 'avg')
+          .getRawOne<{ avg: string }>()
+          .then((r) => parseFloat(r?.avg ?? '0')),
+        qb
+          .clone()
+          .andWhere('p.counted_as_play = true')
+          .andWhere('p.completed_full = true')
+          .getCount(),
+      ]);
+
+    const skippedEvents = totalEvents - totalPlays; // events that didn't reach 30s
+    const skipRate = totalEvents > 0 ? skippedEvents / totalEvents : 0;
+    const completionRate = totalPlays > 0 ? completedCount / totalPlays : 0;
+
+    const uniqueListeners = await this.trackPlayRepo
+      .createQueryBuilder('p')
+      .select('COUNT(DISTINCT COALESCE(p.user_id::text, p.session_id))', 'cnt')
+      .where('p.track_id = :trackId', { trackId })
+      .andWhere('p.counted_as_play = true')
+      .andWhere('p.played_at >= :since', { since })
+      .getRawOne<{ cnt: string }>()
+      .then((r) => parseInt(r?.cnt ?? '0', 10));
+
+    return {
+      trackId,
+      totalPlays,
+      uniqueListeners,
+      completionRate: parseFloat(completionRate.toFixed(4)),
+      skipRate: parseFloat(skipRate.toFixed(4)),
+      avgListenDuration: parseFloat(avgDuration.toFixed(2)),
+      period,
+    };
+  }
+
+  // ─── Source Attribution ───────────────────────────────────────────────────
+
+  async getTrackSources(trackId: string): Promise<SourceBreakdownDto> {
+    const rows = await this.trackPlayRepo
+      .createQueryBuilder('p')
+      .select('p.source', 'source')
+      .addSelect('COUNT(*)', 'cnt')
+      .where('p.track_id = :trackId', { trackId })
+      .andWhere('p.counted_as_play = true')
+      .groupBy('p.source')
+      .getRawMany<{ source: PlaySource; cnt: string }>();
+
+    const sources = Object.values(PlaySource).reduce(
+      (acc, s) => ({ ...acc, [s]: 0 }),
+      {} as Record<PlaySource, number>,
+    );
+    rows.forEach((r) => {
+      sources[r.source] = parseInt(r.cnt, 10);
+    });
+
+    return { trackId, sources };
+  }
+
+  // ─── Artist Overview ──────────────────────────────────────────────────────
+
+  async getArtistOverview(artistId: string): Promise<ArtistOverviewDto> {
+    // Fetch per-track aggregates for this artist
+    const trackRows = await this.dataSource
+      .createQueryBuilder()
+      .select('p.track_id', 'trackId')
+      .addSelect('COUNT(p.id)', 'plays')
+      .addSelect(
+        'AVG(CASE WHEN p.completed_full THEN 1.0 ELSE 0.0 END)',
+        'completionRate',
+      )
+      .from(TrackPlay, 'p')
+      .innerJoin('tracks', 't', 't.id = p.track_id AND t.artist_id = :artistId', {
+        artistId,
+      })
+      .where('p.counted_as_play = true')
+      .groupBy('p.track_id')
+      .orderBy('plays', 'DESC')
+      .getRawMany<{ trackId: string; plays: string; completionRate: string }>();
+
+    const totalPlays = trackRows.reduce((s, r) => s + parseInt(r.plays, 10), 0);
+    const avgCompletionRate =
+      trackRows.length > 0
+        ? trackRows.reduce((s, r) => s + parseFloat(r.completionRate), 0) /
+          trackRows.length
+        : 0;
+
+    const uniqueListeners = await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(DISTINCT COALESCE(p.user_id::text, p.session_id))', 'cnt')
+      .from(TrackPlay, 'p')
+      .innerJoin('tracks', 't', 't.id = p.track_id AND t.artist_id = :artistId', {
+        artistId,
+      })
+      .where('p.counted_as_play = true')
+      .getRawOne<{ cnt: string }>()
+      .then((r) => parseInt(r?.cnt ?? '0', 10));
+
+    const topTracks: TopTrackDto[] = trackRows.slice(0, 5).map((r) => ({
+      trackId: r.trackId,
+      plays: parseInt(r.plays, 10),
+      completionRate: parseFloat(parseFloat(r.completionRate).toFixed(4)),
+    }));
+
+    return {
+      artistId,
+      totalPlays,
+      uniqueListeners,
+      totalTracks: trackRows.length,
+      avgCompletionRate: parseFloat(avgCompletionRate.toFixed(4)),
+      topTracks,
+    };
+  }
+
+  // ─── Top Tracks ───────────────────────────────────────────────────────────
+
+  async getTopTracks(period = '7d', limit = 20): Promise<TopTracksDto> {
+    const since = this.periodToDate(period);
+
+    const rows = await this.trackPlayRepo
+      .createQueryBuilder('p')
+      .select('p.track_id', 'trackId')
+      .addSelect('COUNT(p.id)', 'plays')
+      .addSelect(
+        'AVG(CASE WHEN p.completed_full THEN 1.0 ELSE 0.0 END)',
+        'completionRate',
+      )
+      .where('p.counted_as_play = true')
+      .andWhere('p.played_at >= :since', { since })
+      .groupBy('p.track_id')
+      .orderBy('plays', 'DESC')
+      .limit(limit)
+      .getRawMany<{ trackId: string; plays: string; completionRate: string }>();
+
+    return {
+      period,
+      tracks: rows.map((r) => ({
+        trackId: r.trackId,
+        plays: parseInt(r.plays, 10),
+        completionRate: parseFloat(parseFloat(r.completionRate).toFixed(4)),
+      })),
+    };
+  }
+
+  // ─── Period Helper ────────────────────────────────────────────────────────
+
+  periodToDate(period: string): Date {
+    const now = new Date();
+    const match = /^(\d+)([dwhm])$/.exec(period);
+    if (!match) throw new BadRequestException(`Invalid period format: ${period}. Use e.g. 7d, 4w, 1m`);
+
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+
+    switch (unit) {
+      case 'd':
+        now.setDate(now.getDate() - value);
+        break;
+      case 'w':
+        now.setDate(now.getDate() - value * 7);
+        break;
+      case 'h':
+        now.setHours(now.getHours() - value);
+        break;
+      case 'm':
+        now.setMonth(now.getMonth() - value);
+        break;
+    }
+    return now;
+  }
+}

--- a/backend/src/track-play-count/record-play.dto.ts
+++ b/backend/src/track-play-count/record-play.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsUUID,
+  IsInt,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { PlaySource } from '../entities/track-play.entity';
+
+export class RecordPlayDto {
+  @ApiProperty({ description: 'Track UUID' })
+  @IsUUID()
+  trackId: string;
+
+  @ApiPropertyOptional({ description: 'Authenticated user UUID' })
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @ApiProperty({ description: 'Anonymous session identifier' })
+  @IsString()
+  sessionId: string;
+
+  @ApiProperty({ description: 'Seconds the track was listened to', minimum: 0 })
+  @IsInt()
+  @Min(0)
+  @Max(86400)
+  listenDuration: number;
+
+  @ApiProperty({ description: 'Did the listener finish the entire track?' })
+  @IsBoolean()
+  completedFull: boolean;
+
+  @ApiProperty({ enum: PlaySource, description: 'Where the play originated' })
+  @IsEnum(PlaySource)
+  source: PlaySource;
+}

--- a/backend/src/track-play-count/track-play.entity.ts
+++ b/backend/src/track-play-count/track-play.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+
+export enum PlaySource {
+  SEARCH = 'search',
+  PLAYLIST = 'playlist',
+  ARTIST_PROFILE = 'artist_profile',
+  TIP_FEED = 'tip_feed',
+  DIRECT = 'direct',
+}
+
+@Entity('track_plays')
+@Index(['trackId', 'userId', 'playedAt'])
+@Index(['trackId', 'sessionId', 'playedAt'])
+@Index(['ipHash', 'trackId', 'playedAt'])
+export class TrackPlay {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'track_id', type: 'uuid' })
+  @Index()
+  trackId: string;
+
+  @Column({ name: 'user_id', type: 'uuid', nullable: true })
+  @Index()
+  userId: string | null;
+
+  @Column({ name: 'session_id', type: 'varchar', length: 128 })
+  sessionId: string;
+
+  @Column({ name: 'listen_duration', type: 'integer' })
+  listenDuration: number;
+
+  @Column({ name: 'completed_full', type: 'boolean', default: false })
+  completedFull: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: PlaySource,
+    default: PlaySource.DIRECT,
+  })
+  source: PlaySource;
+
+  @Column({ name: 'ip_hash', type: 'varchar', length: 64 })
+  ipHash: string;
+
+  @Column({ name: 'counted_as_play', type: 'boolean', default: false })
+  countedAsPlay: boolean;
+
+  @CreateDateColumn({ name: 'played_at' })
+  playedAt: Date;
+}


### PR DESCRIPTION
…points

- Add PlayCountService to handle recording plays, retrieving track stats, and artist overviews.
- Create PlayCountModule to encapsulate related functionality.
- Implement RecordPlayDto for validating incoming play records.
- Define TrackPlay entity with necessary fields and relationships.
- Add endpoints for recording plays, fetching track stats, artist overview, and top tracks.
- Implement unit and end-to-end tests for service and controller functionality.

Closes #116 