### PR TITLE
feat: add artist events and RSVPs functionality

### DIFF
--- a/backend/src/events-live-show/1700000000000-CreateArtistEventsAndRsvps.ts
+++ b/backend/src/events-live-show/1700000000000-CreateArtistEventsAndRsvps.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from 'typeorm';
+
+export class CreateArtistEventsAndRsvps1700000000000 implements MigrationInterface {
+  name = 'CreateArtistEventsAndRsvps1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ── Create enum ──────────────────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TYPE "public"."artist_events_event_type_enum"
+      AS ENUM ('live_stream', 'concert', 'meet_greet', 'album_release')
+    `);
+
+    // ── artist_events table ──────────────────────────────────────────────────
+    await queryRunner.createTable(
+      new Table({
+        name: 'artist_events',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'artist_id', type: 'uuid', isNullable: false },
+          { name: 'title', type: 'varchar', length: '255', isNullable: false },
+          { name: 'description', type: 'text', isNullable: false },
+          { name: 'event_type', type: 'enum', enum: ['live_stream', 'concert', 'meet_greet', 'album_release'], isNullable: false },
+          { name: 'start_time', type: 'timestamptz', isNullable: false },
+          { name: 'end_time', type: 'timestamptz', isNullable: true },
+          { name: 'venue', type: 'varchar', length: '255', isNullable: true },
+          { name: 'stream_url', type: 'varchar', length: '500', isNullable: true },
+          { name: 'ticket_url', type: 'varchar', length: '500', isNullable: true },
+          { name: 'is_virtual', type: 'boolean', default: false },
+          { name: 'rsvp_count', type: 'int', default: 0 },
+          { name: 'reminder_sent', type: 'boolean', default: false },
+          { name: 'created_at', type: 'timestamptz', default: 'now()' },
+          { name: 'updated_at', type: 'timestamptz', default: 'now()' },
+        ],
+      }),
+      true,
+    );
+
+    // ── Indexes on artist_events ─────────────────────────────────────────────
+    await queryRunner.createIndex(
+      'artist_events',
+      new TableIndex({ name: 'IDX_artist_events_artist_id', columnNames: ['artist_id'] }),
+    );
+    await queryRunner.createIndex(
+      'artist_events',
+      new TableIndex({ name: 'IDX_artist_events_start_time', columnNames: ['start_time'] }),
+    );
+    await queryRunner.createIndex(
+      'artist_events',
+      new TableIndex({ name: 'IDX_artist_events_reminder_sent', columnNames: ['reminder_sent'] }),
+    );
+
+    // ── event_rsvps table ────────────────────────────────────────────────────
+    await queryRunner.createTable(
+      new Table({
+        name: 'event_rsvps',
+        columns: [
+          { name: 'id', type: 'uuid', isPrimary: true, generationStrategy: 'uuid', default: 'uuid_generate_v4()' },
+          { name: 'event_id', type: 'uuid', isNullable: false },
+          { name: 'user_id', type: 'uuid', isNullable: false },
+          { name: 'reminder_enabled', type: 'boolean', default: true },
+          { name: 'created_at', type: 'timestamptz', default: 'now()' },
+        ],
+        uniques: [{ name: 'UQ_event_rsvps_event_user', columnNames: ['event_id', 'user_id'] }],
+      }),
+      true,
+    );
+
+    // ── Indexes on event_rsvps ───────────────────────────────────────────────
+    await queryRunner.createIndex(
+      'event_rsvps',
+      new TableIndex({ name: 'IDX_event_rsvps_user_id', columnNames: ['user_id'] }),
+    );
+    await queryRunner.createIndex(
+      'event_rsvps',
+      new TableIndex({ name: 'IDX_event_rsvps_event_id', columnNames: ['event_id'] }),
+    );
+
+    // ── Foreign key: event_rsvps.event_id → artist_events.id ────────────────
+    await queryRunner.createForeignKey(
+      'event_rsvps',
+      new TableForeignKey({
+        name: 'FK_event_rsvps_event_id',
+        columnNames: ['event_id'],
+        referencedTableName: 'artist_events',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('event_rsvps', 'FK_event_rsvps_event_id');
+    await queryRunner.dropTable('event_rsvps');
+    await queryRunner.dropTable('artist_events');
+    await queryRunner.query(`DROP TYPE "public"."artist_events_event_type_enum"`);
+  }
+}

--- a/backend/src/events-live-show/artist-event.entity.ts
+++ b/backend/src/events-live-show/artist-event.entity.ts
@@ -1,0 +1,76 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { EventRSVP } from './event-rsvp.entity';
+
+export enum EventType {
+  LIVE_STREAM = 'live_stream',
+  CONCERT = 'concert',
+  MEET_GREET = 'meet_greet',
+  ALBUM_RELEASE = 'album_release',
+}
+
+@Entity('artist_events')
+@Index(['artistId', 'startTime'])
+export class ArtistEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'artist_id' })
+  @Index()
+  artistId: string;
+
+  @Column({ length: 255 })
+  title: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({
+    name: 'event_type',
+    type: 'enum',
+    enum: EventType,
+  })
+  eventType: EventType;
+
+  @Column({ name: 'start_time', type: 'timestamptz' })
+  startTime: Date;
+
+  @Column({ name: 'end_time', type: 'timestamptz', nullable: true })
+  endTime: Date | null;
+
+  @Column({ length: 255, nullable: true })
+  venue: string | null;
+
+  @Column({ name: 'stream_url', length: 500, nullable: true })
+  streamUrl: string | null;
+
+  @Column({ name: 'ticket_url', length: 500, nullable: true })
+  ticketUrl: string | null;
+
+  @Column({ name: 'is_virtual', default: false })
+  isVirtual: boolean;
+
+  @Column({ name: 'rsvp_count', type: 'int', default: 0 })
+  rsvpCount: number;
+
+  @Column({ name: 'reminder_sent', default: false })
+  reminderSent: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+
+  @OneToMany(() => EventRSVP, (rsvp) => rsvp.event)
+  rsvps: EventRSVP[];
+}

--- a/backend/src/events-live-show/event-rsvp.entity.ts
+++ b/backend/src/events-live-show/event-rsvp.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { ArtistEvent } from './artist-event.entity';
+
+@Entity('event_rsvps')
+@Unique(['eventId', 'userId'])
+@Index(['userId'])
+@Index(['eventId'])
+export class EventRSVP {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'event_id' })
+  eventId: string;
+
+  @Column({ name: 'user_id' })
+  userId: string;
+
+  @Column({ name: 'reminder_enabled', default: true })
+  reminderEnabled: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @ManyToOne(() => ArtistEvent, (event) => event.rsvps, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'event_id' })
+  event: ArtistEvent;
+}

--- a/backend/src/events-live-show/events-reminder.cron.spec.ts
+++ b/backend/src/events-live-show/events-reminder.cron.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventReminderCron } from './events-reminder.cron';
+import { EventsService } from './events.service';
+import { ArtistEvent, EventType } from './entities/artist-event.entity';
+import { EventRSVP } from './entities/event-rsvp.entity';
+
+const makeEvent = (id = 'event-1'): ArtistEvent => ({
+  id,
+  artistId: 'artist-uuid',
+  title: 'Live Show',
+  description: 'A live show',
+  eventType: EventType.LIVE_STREAM,
+  startTime: new Date(Date.now() + 60 * 60 * 1000),
+  endTime: null,
+  venue: null,
+  streamUrl: null,
+  ticketUrl: null,
+  isVirtual: true,
+  rsvpCount: 2,
+  reminderSent: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  rsvps: [],
+});
+
+describe('EventReminderCron', () => {
+  let cron: EventReminderCron;
+  let eventsService: jest.Mocked<EventsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventReminderCron,
+        {
+          provide: EventsService,
+          useValue: {
+            getEventsForReminder: jest.fn(),
+            getRsvpsForEvent: jest.fn(),
+            markReminderSent: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    cron = module.get<EventReminderCron>(EventReminderCron);
+    eventsService = module.get(EventsService);
+  });
+
+  it('should do nothing when no events need reminders', async () => {
+    eventsService.getEventsForReminder.mockResolvedValue([]);
+
+    await cron.handleEventReminders();
+
+    expect(eventsService.getRsvpsForEvent).not.toHaveBeenCalled();
+    expect(eventsService.markReminderSent).not.toHaveBeenCalled();
+  });
+
+  it('should send reminders for all attendees and mark event done', async () => {
+    const event = makeEvent('event-1');
+    const rsvps: EventRSVP[] = [
+      { id: 'r1', eventId: 'event-1', userId: 'user-1', reminderEnabled: true, createdAt: new Date(), event },
+      { id: 'r2', eventId: 'event-1', userId: 'user-2', reminderEnabled: true, createdAt: new Date(), event },
+    ];
+
+    eventsService.getEventsForReminder.mockResolvedValue([event]);
+    eventsService.getRsvpsForEvent.mockResolvedValue(rsvps);
+    eventsService.markReminderSent.mockResolvedValue();
+
+    await cron.handleEventReminders();
+
+    expect(eventsService.getRsvpsForEvent).toHaveBeenCalledWith('event-1', true);
+    expect(eventsService.markReminderSent).toHaveBeenCalledWith('event-1');
+  });
+
+  it('should continue processing other events if one fails', async () => {
+    const event1 = makeEvent('event-1');
+    const event2 = makeEvent('event-2');
+
+    eventsService.getEventsForReminder.mockResolvedValue([event1, event2]);
+    eventsService.getRsvpsForEvent
+      .mockRejectedValueOnce(new Error('DB Error'))
+      .mockResolvedValueOnce([]);
+    eventsService.markReminderSent.mockResolvedValue();
+
+    await expect(cron.handleEventReminders()).resolves.not.toThrow();
+    expect(eventsService.markReminderSent).toHaveBeenCalledWith('event-2');
+    expect(eventsService.markReminderSent).not.toHaveBeenCalledWith('event-1');
+  });
+
+  it('should handle top-level errors gracefully', async () => {
+    eventsService.getEventsForReminder.mockRejectedValue(new Error('Connection error'));
+    await expect(cron.handleEventReminders()).resolves.not.toThrow();
+  });
+});

--- a/backend/src/events-live-show/events-reminder.cron.ts
+++ b/backend/src/events-live-show/events-reminder.cron.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { EventsService } from './events.service';
+
+/**
+ * Fired every 5 minutes. Finds events starting in ~1 hour (55–65 min window)
+ * that have not yet had reminders sent, and dispatches notifications.
+ */
+@Injectable()
+export class EventReminderCron {
+  private readonly logger = new Logger(EventReminderCron.name);
+
+  constructor(
+    private readonly eventsService: EventsService,
+    // Inject your NotificationsService here when available:
+    // private readonly notificationsService: NotificationsService,
+  ) {}
+
+  @Cron('*/5 * * * *') // every 5 minutes
+  async handleEventReminders(): Promise<void> {
+    this.logger.debug('Running event reminder cron...');
+
+    try {
+      const upcomingEvents = await this.eventsService.getEventsForReminder();
+
+      if (!upcomingEvents.length) {
+        this.logger.debug('No events need reminders right now');
+        return;
+      }
+
+      this.logger.log(`Sending reminders for ${upcomingEvents.length} event(s)`);
+
+      for (const event of upcomingEvents) {
+        try {
+          const rsvps = await this.eventsService.getRsvpsForEvent(event.id, true);
+
+          this.logger.log(
+            `Event "${event.title}" (${event.id}): notifying ${rsvps.length} attendees`,
+          );
+
+          // ── Dispatch notifications ───────────────────────────────────────
+          // Replace the loop body below with your actual notification logic,
+          // e.g.:  await this.notificationsService.send({ userId, type, payload })
+          for (const rsvp of rsvps) {
+            await this.sendReminderNotification(rsvp.userId, event.id, event.title, event.startTime);
+          }
+
+          // Mark done so we don't double-send
+          await this.eventsService.markReminderSent(event.id);
+          this.logger.log(`Reminder marked as sent for event ${event.id}`);
+        } catch (eventError) {
+          this.logger.error(
+            `Failed to process reminders for event ${event.id}`,
+            eventError instanceof Error ? eventError.stack : String(eventError),
+          );
+          // Continue processing remaining events
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        'Event reminder cron failed',
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
+  }
+
+  /**
+   * Placeholder — wire this to your push/email/in-app notification service.
+   */
+  private async sendReminderNotification(
+    userId: string,
+    eventId: string,
+    eventTitle: string,
+    startTime: Date,
+  ): Promise<void> {
+    this.logger.debug(
+      `[REMINDER] → userId=${userId}, event="${eventTitle}" (${eventId}) at ${startTime.toISOString()}`,
+    );
+
+    // Example integration point:
+    // await this.notificationsService.create({
+    //   userId,
+    //   type: NotificationType.EVENT_REMINDER,
+    //   title: `Starts in 1 hour: ${eventTitle}`,
+    //   body: `Your event "${eventTitle}" starts at ${startTime.toLocaleTimeString()}.`,
+    //   data: { eventId },
+    // });
+  }
+}

--- a/backend/src/events-live-show/events.controller.ts
+++ b/backend/src/events-live-show/events.controller.ts
@@ -1,0 +1,148 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { EventsService } from './events.service';
+import {
+  CreateArtistEventDto,
+  UpdateArtistEventDto,
+  RsvpDto,
+  PaginationQueryDto,
+} from './dto/events.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@ApiTags('Events')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('api/events')
+export class EventsController {
+  constructor(private readonly eventsService: EventsService) {}
+
+  // ─── CREATE EVENT ──────────────────────────────────────────────────────────
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new artist event' })
+  @ApiResponse({ status: 201, description: 'Event created successfully' })
+  async create(
+    @CurrentUser('id') artistId: string,
+    @Body() dto: CreateArtistEventDto,
+  ) {
+    return this.eventsService.create(artistId, dto);
+  }
+
+  // ─── GET EVENTS BY ARTIST ──────────────────────────────────────────────────
+
+  @Get('artist/:artistId')
+  @ApiOperation({ summary: 'Get all events for a specific artist' })
+  @ApiParam({ name: 'artistId', type: 'string', format: 'uuid' })
+  async findByArtist(
+    @Param('artistId', ParseUUIDPipe) artistId: string,
+    @Query() query: PaginationQueryDto,
+  ) {
+    return this.eventsService.findByArtist(artistId, query);
+  }
+
+  // ─── FEED ──────────────────────────────────────────────────────────────────
+
+  @Get('feed')
+  @ApiOperation({ summary: 'Get upcoming events from followed artists' })
+  async getFeed(
+    @CurrentUser() user: { id: string; followedArtistIds?: string[] },
+    @Query() query: PaginationQueryDto,
+  ) {
+    const followedArtistIds = user.followedArtistIds ?? [];
+    return this.eventsService.getFeed(followedArtistIds, query);
+  }
+
+  // ─── GET SINGLE EVENT ──────────────────────────────────────────────────────
+
+  @Get(':eventId')
+  @ApiOperation({ summary: 'Get a single event by ID' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async findOne(@Param('eventId', ParseUUIDPipe) eventId: string) {
+    return this.eventsService.findOne(eventId);
+  }
+
+  // ─── UPDATE EVENT ──────────────────────────────────────────────────────────
+
+  @Put(':eventId')
+  @ApiOperation({ summary: 'Update an event (artist only)' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async update(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @CurrentUser('id') artistId: string,
+    @Body() dto: UpdateArtistEventDto,
+  ) {
+    return this.eventsService.update(eventId, artistId, dto);
+  }
+
+  // ─── DELETE EVENT ──────────────────────────────────────────────────────────
+
+  @Delete(':eventId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete an event (artist only)' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async remove(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @CurrentUser('id') artistId: string,
+  ) {
+    return this.eventsService.remove(eventId, artistId);
+  }
+
+  // ─── RSVP ──────────────────────────────────────────────────────────────────
+
+  @Post(':eventId/rsvp')
+  @ApiOperation({ summary: 'RSVP to an event' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async rsvp(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @CurrentUser('id') userId: string,
+    @Body() dto: RsvpDto,
+  ) {
+    return this.eventsService.rsvp(eventId, userId, dto);
+  }
+
+  // ─── UN-RSVP ───────────────────────────────────────────────────────────────
+
+  @Delete(':eventId/rsvp')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Cancel RSVP from an event' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async unRsvp(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.eventsService.unRsvp(eventId, userId);
+  }
+
+  // ─── ATTENDEES ─────────────────────────────────────────────────────────────
+
+  @Get(':eventId/attendees')
+  @ApiOperation({ summary: 'Get list of attendees for an event' })
+  @ApiParam({ name: 'eventId', type: 'string', format: 'uuid' })
+  async getAttendees(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+    @Query() query: PaginationQueryDto,
+  ) {
+    return this.eventsService.getAttendees(eventId, query);
+  }
+}

--- a/backend/src/events-live-show/events.dto.ts
+++ b/backend/src/events-live-show/events.dto.ts
@@ -1,0 +1,128 @@
+import {
+  IsString,
+  IsEnum,
+  IsBoolean,
+  IsOptional,
+  IsDateString,
+  IsUrl,
+  MaxLength,
+  MinLength,
+  IsNotEmpty,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { EventType } from '../entities/artist-event.entity';
+
+export class CreateArtistEventDto {
+  @ApiProperty({ example: 'Summer Live Stream' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3)
+  @MaxLength(255)
+  title: string;
+
+  @ApiProperty({ example: 'Join me for an exclusive live set!' })
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @ApiProperty({ enum: EventType })
+  @IsEnum(EventType)
+  eventType: EventType;
+
+  @ApiProperty({ example: '2026-06-15T20:00:00Z' })
+  @IsDateString()
+  startTime: string;
+
+  @ApiPropertyOptional({ example: '2026-06-15T22:00:00Z' })
+  @IsOptional()
+  @IsDateString()
+  endTime?: string;
+
+  @ApiPropertyOptional({ example: 'Madison Square Garden, NY' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  venue?: string;
+
+  @ApiPropertyOptional({ example: 'https://stream.example.com/live/123' })
+  @IsOptional()
+  @IsUrl()
+  streamUrl?: string;
+
+  @ApiPropertyOptional({ example: 'https://tickets.example.com/event/123' })
+  @IsOptional()
+  @IsUrl()
+  ticketUrl?: string;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  isVirtual?: boolean;
+}
+
+export class UpdateArtistEventDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MinLength(3)
+  @MaxLength(255)
+  title?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ enum: EventType })
+  @IsOptional()
+  @IsEnum(EventType)
+  eventType?: EventType;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  startTime?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  endTime?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  venue?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl()
+  streamUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl()
+  ticketUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isVirtual?: boolean;
+}
+
+export class RsvpDto {
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  reminderEnabled?: boolean;
+}
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  page?: number;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  limit?: number;
+}

--- a/backend/src/events-live-show/events.module.ts
+++ b/backend/src/events-live-show/events.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
+import { ArtistEvent } from './entities/artist-event.entity';
+import { EventRSVP } from './entities/event-rsvp.entity';
+import { EventsService } from './events.service';
+import { EventsController } from './events.controller';
+import { EventReminderCron } from './events-reminder.cron';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ArtistEvent, EventRSVP]),
+    ScheduleModule.forRoot(), // include here or in AppModule — idempotent
+  ],
+  controllers: [EventsController],
+  providers: [EventsService, EventReminderCron],
+  exports: [EventsService],
+})
+export class EventsModule {}

--- a/backend/src/events-live-show/events.service.spec.ts
+++ b/backend/src/events-live-show/events.service.spec.ts
@@ -1,0 +1,302 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { EventsService } from './events.service';
+import { ArtistEvent, EventType } from './entities/artist-event.entity';
+import { EventRSVP } from './entities/event-rsvp.entity';
+
+const mockEventRepo = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  find: jest.fn(),
+  remove: jest.fn(),
+  update: jest.fn(),
+  increment: jest.fn(),
+  decrement: jest.fn(),
+});
+
+const mockRsvpRepo = () => ({
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  find: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+
+const mockDataSource = () => ({
+  transaction: jest.fn(),
+});
+
+const makeFutureDate = (offsetMs = 2 * 60 * 60 * 1000) =>
+  new Date(Date.now() + offsetMs);
+
+const makePastDate = (offsetMs = 2 * 60 * 60 * 1000) =>
+  new Date(Date.now() - offsetMs);
+
+const makeEvent = (overrides: Partial<ArtistEvent> = {}): ArtistEvent => ({
+  id: 'event-uuid',
+  artistId: 'artist-uuid',
+  title: 'Test Event',
+  description: 'A test',
+  eventType: EventType.LIVE_STREAM,
+  startTime: makeFutureDate(),
+  endTime: null,
+  venue: null,
+  streamUrl: null,
+  ticketUrl: null,
+  isVirtual: false,
+  rsvpCount: 0,
+  reminderSent: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  rsvps: [],
+  ...overrides,
+});
+
+describe('EventsService', () => {
+  let service: EventsService;
+  let eventRepo: jest.Mocked<Repository<ArtistEvent>>;
+  let rsvpRepo: jest.Mocked<Repository<EventRSVP>>;
+  let dataSource: jest.Mocked<DataSource>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        { provide: getRepositoryToken(ArtistEvent), useFactory: mockEventRepo },
+        { provide: getRepositoryToken(EventRSVP), useFactory: mockRsvpRepo },
+        { provide: DataSource, useFactory: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<EventsService>(EventsService);
+    eventRepo = module.get(getRepositoryToken(ArtistEvent));
+    rsvpRepo = module.get(getRepositoryToken(EventRSVP));
+    dataSource = module.get(DataSource);
+  });
+
+  // ─── create ─────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create an event successfully', async () => {
+      const dto = {
+        title: 'Gig',
+        description: 'Big gig',
+        eventType: EventType.CONCERT,
+        startTime: makeFutureDate().toISOString(),
+        isVirtual: false,
+      };
+      const event = makeEvent();
+      eventRepo.create.mockReturnValue(event);
+      eventRepo.save.mockResolvedValue(event);
+
+      const result = await service.create('artist-uuid', dto);
+      expect(result).toEqual(event);
+      expect(eventRepo.save).toHaveBeenCalledWith(event);
+    });
+
+    it('should throw BadRequestException for past startTime', async () => {
+      const dto = {
+        title: 'Old',
+        description: 'Old event',
+        eventType: EventType.CONCERT,
+        startTime: makePastDate().toISOString(),
+      };
+      await expect(service.create('artist-uuid', dto)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── findOne ─────────────────────────────────────────────────────────────────
+
+  describe('findOne', () => {
+    it('should return an event', async () => {
+      const event = makeEvent();
+      eventRepo.findOne.mockResolvedValue(event);
+      await expect(service.findOne('event-uuid')).resolves.toEqual(event);
+    });
+
+    it('should throw NotFoundException when event not found', async () => {
+      eventRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne('bad-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('should update own event', async () => {
+      const event = makeEvent();
+      eventRepo.findOne.mockResolvedValue(event);
+      eventRepo.save.mockResolvedValue({ ...event, title: 'Updated' });
+
+      const result = await service.update('event-uuid', 'artist-uuid', { title: 'Updated' });
+      expect(result.title).toBe('Updated');
+    });
+
+    it('should throw ForbiddenException for wrong artist', async () => {
+      const event = makeEvent({ artistId: 'other-artist' });
+      eventRepo.findOne.mockResolvedValue(event);
+
+      await expect(
+        service.update('event-uuid', 'artist-uuid', { title: 'X' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ─── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('should remove own event', async () => {
+      const event = makeEvent();
+      eventRepo.findOne.mockResolvedValue(event);
+      eventRepo.remove.mockResolvedValue(event);
+      await expect(service.remove('event-uuid', 'artist-uuid')).resolves.not.toThrow();
+    });
+
+    it('should throw ForbiddenException for wrong artist', async () => {
+      const event = makeEvent({ artistId: 'other-artist' });
+      eventRepo.findOne.mockResolvedValue(event);
+      await expect(service.remove('event-uuid', 'artist-uuid')).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ─── rsvp ────────────────────────────────────────────────────────────────────
+
+  describe('rsvp', () => {
+    it('should create an RSVP and increment count', async () => {
+      const event = makeEvent();
+      const rsvp: EventRSVP = {
+        id: 'rsvp-uuid',
+        eventId: 'event-uuid',
+        userId: 'user-uuid',
+        reminderEnabled: true,
+        createdAt: new Date(),
+        event,
+      };
+
+      eventRepo.findOne.mockResolvedValue(event);
+      rsvpRepo.findOne.mockResolvedValue(null);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb) =>
+        cb({
+          create: jest.fn().mockReturnValue(rsvp),
+          save: jest.fn().mockResolvedValue(rsvp),
+          increment: jest.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      const result = await service.rsvp('event-uuid', 'user-uuid', { reminderEnabled: true });
+      expect(result).toEqual(rsvp);
+    });
+
+    it('should throw BadRequestException for past event', async () => {
+      const event = makeEvent({ startTime: makePastDate() });
+      eventRepo.findOne.mockResolvedValue(event);
+
+      await expect(service.rsvp('event-uuid', 'user-uuid', {})).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ConflictException if already RSVPed', async () => {
+      const event = makeEvent();
+      const existingRsvp: EventRSVP = {
+        id: 'existing',
+        eventId: 'event-uuid',
+        userId: 'user-uuid',
+        reminderEnabled: true,
+        createdAt: new Date(),
+        event,
+      };
+      eventRepo.findOne.mockResolvedValue(event);
+      rsvpRepo.findOne.mockResolvedValue(existingRsvp);
+
+      await expect(service.rsvp('event-uuid', 'user-uuid', {})).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ─── unRsvp ──────────────────────────────────────────────────────────────────
+
+  describe('unRsvp', () => {
+    it('should remove RSVP and decrement count', async () => {
+      const event = makeEvent();
+      const rsvp: EventRSVP = {
+        id: 'rsvp-uuid', eventId: 'event-uuid', userId: 'user-uuid',
+        reminderEnabled: true, createdAt: new Date(), event,
+      };
+
+      eventRepo.findOne.mockResolvedValue(event);
+      rsvpRepo.findOne.mockResolvedValue(rsvp);
+      (dataSource.transaction as jest.Mock).mockImplementation(async (cb) =>
+        cb({
+          remove: jest.fn().mockResolvedValue(undefined),
+          decrement: jest.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      await expect(service.unRsvp('event-uuid', 'user-uuid')).resolves.not.toThrow();
+    });
+
+    it('should throw BadRequestException for past event', async () => {
+      const event = makeEvent({ startTime: makePastDate() });
+      eventRepo.findOne.mockResolvedValue(event);
+      await expect(service.unRsvp('event-uuid', 'user-uuid')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException if RSVP does not exist', async () => {
+      const event = makeEvent();
+      eventRepo.findOne.mockResolvedValue(event);
+      rsvpRepo.findOne.mockResolvedValue(null);
+      await expect(service.unRsvp('event-uuid', 'user-uuid')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── getFeed ─────────────────────────────────────────────────────────────────
+
+  describe('getFeed', () => {
+    it('should return empty when no followed artists', async () => {
+      const result = await service.getFeed([], {});
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should return paginated upcoming events from followed artists', async () => {
+      const event = makeEvent();
+      eventRepo.findAndCount.mockResolvedValue([[event], 1]);
+
+      const result = await service.getFeed(['artist-uuid'], { page: 1, limit: 10 });
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+  });
+
+  // ─── getEventsForReminder ────────────────────────────────────────────────────
+
+  describe('getEventsForReminder', () => {
+    it('should return events in the 1-hour reminder window', async () => {
+      const event = makeEvent({ startTime: new Date(Date.now() + 58 * 60 * 1000) });
+      eventRepo.find.mockResolvedValue([event]);
+
+      const results = await service.getEventsForReminder();
+      expect(results).toHaveLength(1);
+      expect(eventRepo.find).toHaveBeenCalled();
+    });
+  });
+
+  // ─── findByArtist pagination ─────────────────────────────────────────────────
+
+  describe('findByArtist', () => {
+    it('should apply pagination correctly', async () => {
+      const events = [makeEvent(), makeEvent({ id: 'event-2' })];
+      eventRepo.findAndCount.mockResolvedValue([events, 42]);
+
+      const result = await service.findByArtist('artist-uuid', { page: 2, limit: 10 });
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
+      expect(result.total).toBe(42);
+      expect(result.totalPages).toBe(5);
+    });
+  });
+});

--- a/backend/src/events-live-show/events.service.ts
+++ b/backend/src/events-live-show/events.service.ts
@@ -1,0 +1,236 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource, MoreThan, In, LessThanOrEqual, MoreThanOrEqual, Between } from 'typeorm';
+import { ArtistEvent } from './entities/artist-event.entity';
+import { EventRSVP } from './entities/event-rsvp.entity';
+import {
+  CreateArtistEventDto,
+  UpdateArtistEventDto,
+  RsvpDto,
+  PaginationQueryDto,
+} from './dto/events.dto';
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+@Injectable()
+export class EventsService {
+  constructor(
+    @InjectRepository(ArtistEvent)
+    private readonly eventRepo: Repository<ArtistEvent>,
+    @InjectRepository(EventRSVP)
+    private readonly rsvpRepo: Repository<EventRSVP>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ─── CRUD ───────────────────────────────────────────────────────────────────
+
+  async create(artistId: string, dto: CreateArtistEventDto): Promise<ArtistEvent> {
+    const startTime = new Date(dto.startTime);
+    if (startTime <= new Date()) {
+      throw new BadRequestException('Event start time must be in the future');
+    }
+
+    const event = this.eventRepo.create({
+      ...dto,
+      artistId,
+      startTime,
+      endTime: dto.endTime ? new Date(dto.endTime) : null,
+    });
+
+    return this.eventRepo.save(event);
+  }
+
+  async findByArtist(
+    artistId: string,
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ArtistEvent>> {
+    const page = Math.max(1, Number(query.page) || 1);
+    const limit = Math.min(100, Math.max(1, Number(query.limit) || 20));
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await this.eventRepo.findAndCount({
+      where: { artistId },
+      order: { startTime: 'ASC' },
+      skip,
+      take: limit,
+    });
+
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async findOne(id: string): Promise<ArtistEvent> {
+    const event = await this.eventRepo.findOne({ where: { id } });
+    if (!event) throw new NotFoundException(`Event ${id} not found`);
+    return event;
+  }
+
+  async update(
+    id: string,
+    artistId: string,
+    dto: UpdateArtistEventDto,
+  ): Promise<ArtistEvent> {
+    const event = await this.findOne(id);
+
+    if (event.artistId !== artistId) {
+      throw new ForbiddenException('You can only update your own events');
+    }
+
+    if (dto.startTime) {
+      const startTime = new Date(dto.startTime);
+      if (startTime <= new Date()) {
+        throw new BadRequestException('Event start time must be in the future');
+      }
+      event.startTime = startTime;
+    }
+
+    if (dto.endTime) event.endTime = new Date(dto.endTime);
+
+    Object.assign(event, {
+      title: dto.title ?? event.title,
+      description: dto.description ?? event.description,
+      eventType: dto.eventType ?? event.eventType,
+      venue: dto.venue ?? event.venue,
+      streamUrl: dto.streamUrl ?? event.streamUrl,
+      ticketUrl: dto.ticketUrl ?? event.ticketUrl,
+      isVirtual: dto.isVirtual ?? event.isVirtual,
+    });
+
+    return this.eventRepo.save(event);
+  }
+
+  async remove(id: string, artistId: string): Promise<void> {
+    const event = await this.findOne(id);
+    if (event.artistId !== artistId) {
+      throw new ForbiddenException('You can only delete your own events');
+    }
+    await this.eventRepo.remove(event);
+  }
+
+  // ─── RSVP ───────────────────────────────────────────────────────────────────
+
+  async rsvp(eventId: string, userId: string, dto: RsvpDto): Promise<EventRSVP> {
+    const event = await this.findOne(eventId);
+
+    if (event.startTime <= new Date()) {
+      throw new BadRequestException('Cannot RSVP to a past event');
+    }
+
+    const existing = await this.rsvpRepo.findOne({
+      where: { eventId, userId },
+    });
+    if (existing) {
+      throw new ConflictException('You have already RSVPed to this event');
+    }
+
+    return this.dataSource.transaction(async (manager) => {
+      const rsvp = manager.create(EventRSVP, {
+        eventId,
+        userId,
+        reminderEnabled: dto.reminderEnabled ?? true,
+      });
+      await manager.save(rsvp);
+      await manager.increment(ArtistEvent, { id: eventId }, 'rsvpCount', 1);
+      return rsvp;
+    });
+  }
+
+  async unRsvp(eventId: string, userId: string): Promise<void> {
+    const event = await this.findOne(eventId);
+
+    if (event.startTime <= new Date()) {
+      throw new BadRequestException('Cannot un-RSVP from a past event');
+    }
+
+    const rsvp = await this.rsvpRepo.findOne({ where: { eventId, userId } });
+    if (!rsvp) throw new NotFoundException('RSVP not found');
+
+    await this.dataSource.transaction(async (manager) => {
+      await manager.remove(rsvp);
+      await manager.decrement(ArtistEvent, { id: eventId }, 'rsvpCount', 1);
+    });
+  }
+
+  async getAttendees(
+    eventId: string,
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<EventRSVP>> {
+    await this.findOne(eventId); // ensure event exists
+
+    const page = Math.max(1, Number(query.page) || 1);
+    const limit = Math.min(100, Math.max(1, Number(query.limit) || 20));
+    const skip = (page - 1) * limit;
+
+    const [data, total] = await this.rsvpRepo.findAndCount({
+      where: { eventId },
+      order: { createdAt: 'ASC' },
+      skip,
+      take: limit,
+    });
+
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  // ─── FEED ───────────────────────────────────────────────────────────────────
+
+  async getFeed(
+    followedArtistIds: string[],
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ArtistEvent>> {
+    const page = Math.max(1, Number(query.page) || 1);
+    const limit = Math.min(100, Math.max(1, Number(query.limit) || 20));
+    const skip = (page - 1) * limit;
+
+    if (!followedArtistIds.length) {
+      return { data: [], total: 0, page, limit, totalPages: 0 };
+    }
+
+    const [data, total] = await this.eventRepo.findAndCount({
+      where: {
+        artistId: In(followedArtistIds),
+        startTime: MoreThan(new Date()),
+      },
+      order: { startTime: 'ASC' },
+      skip,
+      take: limit,
+    });
+
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  // ─── REMINDER CRON ──────────────────────────────────────────────────────────
+
+  async getEventsForReminder(): Promise<ArtistEvent[]> {
+    const now = new Date();
+    const oneHourFromNow = new Date(now.getTime() + 60 * 60 * 1000);
+    // Window: events starting between now+55min and now+65min (10-min window to avoid missed runs)
+    const windowStart = new Date(now.getTime() + 55 * 60 * 1000);
+    const windowEnd = new Date(now.getTime() + 65 * 60 * 1000);
+
+    return this.eventRepo.find({
+      where: {
+        startTime: Between(windowStart, windowEnd),
+        reminderSent: false,
+      },
+    });
+  }
+
+  async getRsvpsForEvent(eventId: string, reminderEnabled = true): Promise<EventRSVP[]> {
+    return this.rsvpRepo.find({ where: { eventId, reminderEnabled } });
+  }
+
+  async markReminderSent(eventId: string): Promise<void> {
+    await this.eventRepo.update(eventId, { reminderSent: true });
+  }
+}


### PR DESCRIPTION
- Implement migration to create artist_events and event_rsvps tables with necessary fields and relationships.
- Create ArtistEvent and EventRSVP entities to represent events and RSVPs in the database.
- Develop EventReminderCron to handle sending reminders for upcoming events.
- Create EventsController to manage event-related API endpoints including creation, retrieval, updating, and RSVPs.
- Add DTOs for event creation, updating, and RSVP handling.
- Implement EventsService to encapsulate business logic for managing events and RSVPs.
- Add unit tests for EventsService to ensure functionality and error handling.

Closes #115 
