### PR TITLE
feat(frontend): add live performance mode screen with realtime tip stage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import SearchPage from "./pages/SearchPage";
 import AnalyticsDashboard from "./components/analytics/AnalyticsDashboard";
 import ArtistProfilePage from "./pages/ArtistProfilePage";
 import InstallPrompt from "./components/InstallPrompt";
+import LivePerformanceMode from "./components/live-performance/LivePerformanceMode";
 
 function App() {
   return (
@@ -32,6 +33,7 @@ function App() {
           <Route path="/analytics" element={<AnalyticsDashboard />} />
           <Route path="/artists/:artistId" element={<ArtistProfilePage />} />
           <Route path="/tips/history" element={<TipHistoryPage />} />
+          <Route path="/live-performance" element={<LivePerformanceMode />} />
           {/* <Route path="/music-player" element={<MusicPlayer />} /> */}
           <Route path="*" element={<NotFoundPage />} />
           <Route path="/onboarding" element={<ArtistOnboarding />} />

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -15,6 +15,7 @@ const AppHeader: React.FC = () => {
     { label: 'Settings', to: '/settings'},
     { label: 'Tip History', to: '/tips/history' },
     { label: 'Analytics', to: '/analytics' },
+    { label: 'Live Mode', to: '/live-performance' },
   ];
 
   const toggleMenu = () => setIsOpen((prev) => !prev);

--- a/frontend/src/components/live-performance/HypeMeter.test.tsx
+++ b/frontend/src/components/live-performance/HypeMeter.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import HypeMeter from './HypeMeter';
+
+describe('HypeMeter', () => {
+  it('renders meter value and applies width', () => {
+    render(<HypeMeter value={72} />);
+
+    expect(screen.getByText('72%')).toBeInTheDocument();
+    const meter = screen.getByRole('meter', { name: 'Crowd hype meter' });
+    expect(meter).toHaveStyle({ width: '72%' });
+  });
+
+  it('clamps out-of-range values', () => {
+    render(<HypeMeter value={180} />);
+
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    const meter = screen.getByRole('meter', { name: 'Crowd hype meter' });
+    expect(meter).toHaveStyle({ width: '100%' });
+  });
+});

--- a/frontend/src/components/live-performance/HypeMeter.tsx
+++ b/frontend/src/components/live-performance/HypeMeter.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface HypeMeterProps {
+  value: number;
+}
+
+const HypeMeter: React.FC<HypeMeterProps> = ({ value }) => {
+  const safeValue = Math.max(0, Math.min(100, value));
+  const toneClass =
+    safeValue >= 80
+      ? 'from-gold via-amber-400 to-rose-400'
+      : safeValue >= 50
+      ? 'from-mint via-ice-blue to-blue-primary'
+      : 'from-blue-primary via-sky-500 to-cyan-400';
+
+  return (
+    <div className="rounded-2xl border border-blue-primary/40 bg-navy/80 p-4 shadow-xl">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-xs uppercase tracking-[0.2em] text-ice-blue">Crowd hype</p>
+        <p className="text-sm font-semibold text-white">{safeValue.toFixed(0)}%</p>
+      </div>
+      <div className="h-4 w-full overflow-hidden rounded-full bg-slate-900/80">
+        <div
+          className={`h-full rounded-full bg-gradient-to-r transition-all duration-500 ease-out ${toneClass}`}
+          style={{ width: `${safeValue}%` }}
+          role="meter"
+          aria-label="Crowd hype meter"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={safeValue}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default HypeMeter;

--- a/frontend/src/components/live-performance/LiveLeaderboard.tsx
+++ b/frontend/src/components/live-performance/LiveLeaderboard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { LeaderboardEntry } from './types';
+
+interface LiveLeaderboardProps {
+  entries: LeaderboardEntry[];
+  privacyMode: boolean;
+}
+
+const LiveLeaderboard: React.FC<LiveLeaderboardProps> = ({ entries, privacyMode }) => {
+  const top = entries.slice(0, 5);
+
+  return (
+    <div className="rounded-2xl border border-blue-primary/40 bg-navy/80 p-4 shadow-xl">
+      <h2 className="text-xs uppercase tracking-[0.2em] text-ice-blue">Top tippers (session)</h2>
+      {top.length === 0 ? (
+        <p className="mt-4 text-sm text-slate-300">No tips in this session yet.</p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {top.map((entry, index) => (
+            <li
+              key={`${entry.tipperName}-${index}`}
+              className="flex items-center justify-between rounded-lg border border-slate-700/60 bg-slate-900/40 px-3 py-2"
+            >
+              <div>
+                <p className="text-sm font-semibold text-white">
+                  #{index + 1} {privacyMode ? 'Hidden supporter' : entry.tipperName}
+                </p>
+                <p className="text-xs text-slate-300">{entry.tipCount} tips</p>
+              </div>
+              <p className="text-sm font-bold text-mint">
+                {privacyMode ? '••••' : `${entry.total.toFixed(2)} XLM`}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default LiveLeaderboard;

--- a/frontend/src/components/live-performance/LivePerformanceMode.test.tsx
+++ b/frontend/src/components/live-performance/LivePerformanceMode.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import io from 'socket.io-client';
+import LivePerformanceMode from './LivePerformanceMode';
+
+const mockSocket = {
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  disconnect: vi.fn(),
+  connected: true,
+};
+
+vi.mock('socket.io-client', () => ({
+  default: vi.fn(() => mockSocket),
+}));
+
+describe('LivePerformanceMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('ingests websocket tip notifications and updates session stats', async () => {
+    render(<LivePerformanceMode />);
+
+    fireEvent.click(screen.getByRole('button', { name: /start session/i }));
+
+    const tipHandlerCall = mockSocket.on.mock.calls.find((call) => call[0] === 'tip_notification');
+    expect(tipHandlerCall).toBeDefined();
+
+    await act(async () => {
+      const callback = tipHandlerCall[1] as (payload: unknown) => void;
+      callback({
+        type: 'tip_received',
+        data: {
+          tipId: 'tip-100',
+          amount: 30,
+          asset: 'XLM',
+          senderAddress: 'GABCD1234EFGH5678IJKL9012MNOP3456QRST7890',
+          isAnonymous: false,
+          createdAt: '2026-02-23T20:00:00.000Z',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('30.00 XLM')).toBeInTheDocument();
+      expect(screen.getByText(/Big tip/i)).toBeInTheDocument();
+      expect(screen.getByText(/Incoming tip/i)).toBeInTheDocument();
+    });
+
+    const persisted = JSON.parse(localStorage.getItem('tiptune.livePerformance.session.v1') || '{}');
+    expect(persisted.sessionTotalXlm).toBe(30);
+    expect(persisted.tipCount).toBe(1);
+  });
+
+  it('masks sensitive details in privacy mode and reset clears session stats', async () => {
+    render(<LivePerformanceMode />);
+
+    fireEvent.click(screen.getByRole('button', { name: /start session/i }));
+
+    const tipHandlerCall = mockSocket.on.mock.calls.find((call) => call[0] === 'tip_notification');
+    const callback = tipHandlerCall[1] as (payload: unknown) => void;
+
+    await act(async () => {
+      callback({
+        type: 'tip_received',
+        data: {
+          tipId: 'tip-101',
+          amount: 9,
+          asset: 'XLM',
+          senderAddress: 'GTESTING1234567890ABCDEF1234567890ABCDEF12',
+          isAnonymous: false,
+          createdAt: '2026-02-23T20:02:00.000Z',
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /enable privacy/i }));
+    expect(screen.getByText('Hidden supporter')).toBeInTheDocument();
+    expect(screen.getAllByText('••••').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /reset stats/i }));
+
+    await waitFor(() => {
+      const persisted = JSON.parse(localStorage.getItem('tiptune.livePerformance.session.v1') || '{}');
+      expect(persisted.sessionTotalXlm).toBe(0);
+      expect(persisted.tipCount).toBe(0);
+    });
+  });
+
+  it('connects socket to tips namespace', () => {
+    render(<LivePerformanceMode />);
+    expect(io).toHaveBeenCalledWith(
+      expect.stringContaining('/tips'),
+      expect.objectContaining({ transports: ['websocket'] }),
+    );
+  });
+});

--- a/frontend/src/components/live-performance/LivePerformanceMode.tsx
+++ b/frontend/src/components/live-performance/LivePerformanceMode.tsx
@@ -1,0 +1,385 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import io, { Socket } from 'socket.io-client';
+import { Eye, EyeOff, Maximize, Minimize, Play, RotateCcw, Square } from 'lucide-react';
+import LiveTipAlert from './LiveTipAlert';
+import SessionTicker from './SessionTicker';
+import HypeMeter from './HypeMeter';
+import LiveLeaderboard from './LiveLeaderboard';
+import type { LeaderboardEntry, LiveSessionState, LiveTipEvent } from './types';
+import { truncateAddress } from '../../utils/stellar';
+
+const SESSION_STORAGE_KEY = 'tiptune.livePerformance.session.v1';
+const LARGE_TIP_THRESHOLD_XLM = 25;
+const MAX_ALERTS = 6;
+const MAX_PARTICLES = 24;
+
+interface TipNotificationPayload {
+  type?: string;
+  data?: {
+    tipId?: string;
+    amount?: number;
+    asset?: string;
+    senderAddress?: string;
+    isAnonymous?: boolean;
+    createdAt?: string | Date;
+  };
+}
+
+interface BurstParticle {
+  id: string;
+  x: number;
+  y: number;
+  duration: number;
+  size: number;
+}
+
+const defaultSessionState: LiveSessionState = {
+  artistId: '',
+  isSessionActive: false,
+  privacyMode: false,
+  sessionStartedAt: null,
+  sessionTotalXlm: 0,
+  tipCount: 0,
+  hypeScore: 0,
+  alerts: [],
+  leaderboard: [],
+};
+
+const loadSessionState = (): LiveSessionState => {
+  try {
+    const raw = localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return defaultSessionState;
+    const parsed = JSON.parse(raw) as LiveSessionState;
+    return {
+      ...defaultSessionState,
+      ...parsed,
+      alerts: Array.isArray(parsed.alerts) ? parsed.alerts : [],
+      leaderboard: Array.isArray(parsed.leaderboard) ? parsed.leaderboard : [],
+    };
+  } catch {
+    return defaultSessionState;
+  }
+};
+
+const getSocketBaseUrl = (): string => {
+  const apiUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
+  return apiUrl.replace('/api', '');
+};
+
+const LivePerformanceMode: React.FC = () => {
+  const [session, setSession] = useState<LiveSessionState>(defaultSessionState);
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(Boolean(document.fullscreenElement));
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastTipAt, setLastTipAt] = useState<string | null>(null);
+  const [burstParticles, setBurstParticles] = useState<BurstParticle[]>([]);
+  const socketRef = useRef<Socket | null>(null);
+  const previousArtistIdRef = useRef<string>('');
+
+  useEffect(() => {
+    setSession(loadSessionState());
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+  }, [session]);
+
+  useEffect(() => {
+    const onFullscreenChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setSession((prev) => ({
+        ...prev,
+        hypeScore: Math.max(0, prev.hypeScore - 3),
+      }));
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const addParticleBurst = useCallback(() => {
+    const now = Date.now();
+    const particles: BurstParticle[] = Array.from({ length: MAX_PARTICLES }).map((_, index) => ({
+      id: `${now}-${index}`,
+      x: Math.random() * 100,
+      y: Math.random() * 100,
+      duration: 900 + Math.random() * 1000,
+      size: 5 + Math.random() * 8,
+    }));
+    setBurstParticles(particles);
+    window.setTimeout(() => setBurstParticles([]), 1500);
+  }, []);
+
+  const handleIncomingTip = useCallback(
+    (payload: TipNotificationPayload) => {
+      if (!session.isSessionActive) return;
+      const tip = payload.data;
+      if (!tip || typeof tip.amount !== 'number') return;
+
+      const asset = tip.asset || 'XLM';
+      const isXlmTip = asset.toUpperCase() === 'XLM';
+      const tipper = tip.isAnonymous ? 'Anonymous fan' : truncateAddress(tip.senderAddress || 'Guest fan', 5, 4);
+      const isLargeTip = isXlmTip && tip.amount >= LARGE_TIP_THRESHOLD_XLM;
+
+      const alert: LiveTipEvent = {
+        id: tip.tipId || `tip-${Date.now()}`,
+        tipperName: tipper,
+        amount: tip.amount,
+        asset,
+        createdAt: typeof tip.createdAt === 'string' ? tip.createdAt : new Date().toISOString(),
+        isLargeTip,
+      };
+
+      setSession((prev) => {
+        const existing = prev.leaderboard.find((entry) => entry.tipperName === tipper);
+        const updatedEntry: LeaderboardEntry = existing
+          ? { ...existing, total: existing.total + (isXlmTip ? tip.amount : 0), tipCount: existing.tipCount + 1 }
+          : { tipperName: tipper, total: isXlmTip ? tip.amount : 0, tipCount: 1 };
+
+        const leaderboard = prev.leaderboard
+          .filter((entry) => entry.tipperName !== tipper)
+          .concat(updatedEntry)
+          .sort((a, b) => b.total - a.total);
+
+        return {
+          ...prev,
+          tipCount: prev.tipCount + 1,
+          sessionTotalXlm: prev.sessionTotalXlm + (isXlmTip ? tip.amount : 0),
+          hypeScore: Math.min(100, prev.hypeScore + Math.max(8, tip.amount * 1.2)),
+          alerts: [alert, ...prev.alerts].slice(0, MAX_ALERTS),
+          leaderboard,
+        };
+      });
+
+      setLastTipAt(new Date().toISOString());
+      if (isLargeTip) addParticleBurst();
+    },
+    [addParticleBurst, session.isSessionActive],
+  );
+
+  useEffect(() => {
+    const socket = io(`${getSocketBaseUrl()}/tips`, {
+      transports: ['websocket'],
+    });
+    socketRef.current = socket;
+
+    socket.on('connect', () => {
+      setIsConnected(true);
+      if (session.artistId) {
+        socket.emit('join_artist_room', { artistId: session.artistId });
+      }
+    });
+
+    socket.on('disconnect', () => setIsConnected(false));
+    socket.on('tip_notification', handleIncomingTip);
+
+    return () => {
+      socket.off('tip_notification', handleIncomingTip);
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [handleIncomingTip, session.artistId]);
+
+  useEffect(() => {
+    const socket = socketRef.current;
+    if (!socket || !socket.connected) return;
+
+    const previous = previousArtistIdRef.current;
+    const next = session.artistId.trim();
+
+    if (previous && previous !== next) {
+      socket.emit('leave_artist_room', { artistId: previous });
+    }
+    if (next && next !== previous) {
+      socket.emit('join_artist_room', { artistId: next });
+      previousArtistIdRef.current = next;
+    }
+  }, [session.artistId]);
+
+  const toggleFullscreen = useCallback(async () => {
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen();
+      return;
+    }
+    await document.exitFullscreen();
+  }, []);
+
+  const setArtistId = useCallback((artistId: string) => {
+    setSession((prev) => ({ ...prev, artistId }));
+  }, []);
+
+  const startSession = useCallback(() => {
+    setSession((prev) => ({
+      ...prev,
+      isSessionActive: true,
+      sessionStartedAt: prev.sessionStartedAt || new Date().toISOString(),
+    }));
+  }, []);
+
+  const endSession = useCallback(() => {
+    setSession((prev) => ({ ...prev, isSessionActive: false }));
+  }, []);
+
+  const togglePrivacyMode = useCallback(() => {
+    setSession((prev) => ({ ...prev, privacyMode: !prev.privacyMode }));
+  }, []);
+
+  const resetSession = useCallback(() => {
+    setSession((prev) => ({
+      ...prev,
+      sessionStartedAt: null,
+      sessionTotalXlm: 0,
+      tipCount: 0,
+      hypeScore: 0,
+      alerts: [],
+      leaderboard: [],
+      isSessionActive: false,
+    }));
+    setLastTipAt(null);
+    localStorage.removeItem(SESSION_STORAGE_KEY);
+  }, []);
+
+  const sessionClockLabel = useMemo(() => {
+    if (!session.sessionStartedAt) return 'Not started';
+    return new Date(session.sessionStartedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }, [session.sessionStartedAt]);
+
+  return (
+    <section className="fixed inset-0 z-40 overflow-auto bg-gradient-to-b from-[#050b13] via-[#09192b] to-[#081220] text-white">
+      <div className="relative mx-auto min-h-screen w-full max-w-[1600px] px-4 py-5 sm:px-6 md:px-8">
+        {burstParticles.map((particle) => (
+          <span
+            key={particle.id}
+            className="pointer-events-none absolute rounded-full bg-gold/70"
+            style={{
+              width: particle.size,
+              height: particle.size,
+              left: `${particle.x}%`,
+              top: `${particle.y}%`,
+              animation: `coin-fly ${particle.duration}ms ease-out forwards`,
+            }}
+            aria-hidden="true"
+          />
+        ))}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-primary/40 bg-navy/70 p-3 backdrop-blur">
+          <div>
+            <h1 className="text-2xl font-extrabold tracking-tight">Live Performance Mode</h1>
+            <p className="text-sm text-slate-300">
+              Session started: {sessionClockLabel} | WebSocket: {isConnected ? 'Connected' : 'Disconnected'}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={togglePrivacyMode}
+              className="inline-flex items-center gap-2 rounded-lg border border-slate-600 px-3 py-2 text-sm hover:bg-slate-800/60"
+            >
+              {session.privacyMode ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+              {session.privacyMode ? 'Disable privacy' : 'Enable privacy'}
+            </button>
+            <button
+              type="button"
+              onClick={toggleFullscreen}
+              className="inline-flex items-center gap-2 rounded-lg border border-slate-600 px-3 py-2 text-sm hover:bg-slate-800/60"
+            >
+              {isFullscreen ? <Minimize className="h-4 w-4" /> : <Maximize className="h-4 w-4" />}
+              {isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-12">
+          <div className="rounded-2xl border border-blue-primary/40 bg-navy/80 p-4 lg:col-span-4">
+            <label htmlFor="live-artist-id" className="text-xs uppercase tracking-[0.2em] text-ice-blue">
+              Artist ID (room subscription)
+            </label>
+            <input
+              id="live-artist-id"
+              className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-white outline-none focus:border-blue-primary"
+              value={session.artistId}
+              onChange={(event) => setArtistId(event.target.value)}
+              placeholder="Enter artist UUID"
+            />
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={startSession}
+                className="inline-flex items-center gap-2 rounded-lg bg-mint px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-mint/90"
+              >
+                <Play className="h-4 w-4" />
+                Start session
+              </button>
+              <button
+                type="button"
+                onClick={endSession}
+                className="inline-flex items-center gap-2 rounded-lg bg-amber-300 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-amber-200"
+              >
+                <Square className="h-4 w-4" />
+                End session
+              </button>
+              <button
+                type="button"
+                onClick={resetSession}
+                className="inline-flex items-center gap-2 rounded-lg bg-rose-400 px-3 py-2 text-sm font-semibold text-slate-900 hover:bg-rose-300"
+              >
+                <RotateCcw className="h-4 w-4" />
+                Reset stats
+              </button>
+            </div>
+            <p className="mt-2 text-xs text-slate-300">
+              Stats persist locally until reset. Session can be paused/resumed.
+            </p>
+          </div>
+
+          <div className="lg:col-span-4">
+            <SessionTicker
+              totalXlm={session.sessionTotalXlm}
+              tipCount={session.tipCount}
+              isSessionActive={session.isSessionActive}
+              privacyMode={session.privacyMode}
+            />
+            <p className="mt-2 text-xs text-slate-300">
+              Last tip: {lastTipAt ? new Date(lastTipAt).toLocaleTimeString() : 'No tips yet'}
+            </p>
+          </div>
+
+          <div className="lg:col-span-4">
+            <HypeMeter value={session.hypeScore} />
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-12">
+          <div className="xl:col-span-8">
+            <div className="rounded-2xl border border-blue-primary/40 bg-navy/60 p-4">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-ice-blue">
+                Live tip alerts
+              </h2>
+              <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+                {session.alerts.length === 0 ? (
+                  <p className="col-span-full rounded-xl border border-slate-700 bg-slate-900/40 p-5 text-sm text-slate-300">
+                    Waiting for live tips. Start session and ensure an artist room is selected.
+                  </p>
+                ) : (
+                  session.alerts.map((tip) => (
+                    <LiveTipAlert key={tip.id} tip={tip} privacyMode={session.privacyMode} />
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="xl:col-span-4">
+            <LiveLeaderboard entries={session.leaderboard} privacyMode={session.privacyMode} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default LivePerformanceMode;

--- a/frontend/src/components/live-performance/LiveTipAlert.test.tsx
+++ b/frontend/src/components/live-performance/LiveTipAlert.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import LiveTipAlert from './LiveTipAlert';
+
+const baseTip = {
+  id: 'tip-1',
+  tipperName: 'GABC...1234',
+  amount: 12.5,
+  asset: 'XLM',
+  createdAt: '2026-02-23T10:00:00.000Z',
+  isLargeTip: false,
+};
+
+describe('LiveTipAlert', () => {
+  it('renders tipper and amount when privacy mode is off', () => {
+    render(<LiveTipAlert tip={baseTip} privacyMode={false} />);
+
+    expect(screen.getByText('GABC...1234')).toBeInTheDocument();
+    expect(screen.getByText('12.50 XLM')).toBeInTheDocument();
+  });
+
+  it('hides sensitive details when privacy mode is on', () => {
+    render(<LiveTipAlert tip={baseTip} privacyMode={true} />);
+
+    expect(screen.getByText('Hidden supporter')).toBeInTheDocument();
+    expect(screen.getByText('Hidden amount')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/live-performance/LiveTipAlert.tsx
+++ b/frontend/src/components/live-performance/LiveTipAlert.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { LiveTipEvent } from './types';
+
+interface LiveTipAlertProps {
+  tip: LiveTipEvent;
+  privacyMode: boolean;
+}
+
+const LiveTipAlert: React.FC<LiveTipAlertProps> = ({ tip, privacyMode }) => {
+  const tipperLabel = privacyMode ? 'Hidden supporter' : tip.tipperName;
+  const amountLabel = privacyMode ? 'Hidden amount' : `${tip.amount.toFixed(2)} ${tip.asset}`;
+
+  return (
+    <div
+      className={`rounded-2xl border p-4 backdrop-blur-sm shadow-lg transition-all duration-300 animate-slide-bounce ${
+        tip.isLargeTip
+          ? 'border-gold bg-gold/20 shadow-gold/40'
+          : 'border-blue-primary/40 bg-navy/80 shadow-blue-primary/20'
+      }`}
+      aria-live="polite"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium text-ice-blue uppercase tracking-wide">Incoming tip</p>
+        {tip.isLargeTip && (
+          <span className="rounded-full bg-gold/30 px-2 py-1 text-xs font-semibold text-gold">
+            Big tip
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-lg font-bold text-white">{tipperLabel}</p>
+      <p className="text-xl font-extrabold text-mint">{amountLabel}</p>
+      <p className="mt-1 text-xs text-slate-300">
+        {new Date(tip.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+      </p>
+    </div>
+  );
+};
+
+export default LiveTipAlert;

--- a/frontend/src/components/live-performance/SessionTicker.tsx
+++ b/frontend/src/components/live-performance/SessionTicker.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface SessionTickerProps {
+  totalXlm: number;
+  tipCount: number;
+  isSessionActive: boolean;
+  privacyMode: boolean;
+}
+
+const SessionTicker: React.FC<SessionTickerProps> = ({
+  totalXlm,
+  tipCount,
+  isSessionActive,
+  privacyMode,
+}) => {
+  return (
+    <div className="rounded-2xl border border-blue-primary/40 bg-navy/80 px-5 py-4 shadow-xl">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.2em] text-ice-blue">Session total</p>
+        <span
+          className={`h-2 w-2 rounded-full ${isSessionActive ? 'bg-mint animate-pulse' : 'bg-slate-500'}`}
+          aria-label={isSessionActive ? 'Session active' : 'Session paused'}
+        />
+      </div>
+      <p className="mt-2 text-3xl font-extrabold text-white">
+        {privacyMode ? '••••' : `${totalXlm.toFixed(2)} XLM`}
+      </p>
+      <p className="mt-1 text-sm text-slate-300">{tipCount} tips this session</p>
+    </div>
+  );
+};
+
+export default SessionTicker;

--- a/frontend/src/components/live-performance/index.ts
+++ b/frontend/src/components/live-performance/index.ts
@@ -1,0 +1,5 @@
+export { default as LivePerformanceMode } from './LivePerformanceMode';
+export { default as LiveTipAlert } from './LiveTipAlert';
+export { default as SessionTicker } from './SessionTicker';
+export { default as HypeMeter } from './HypeMeter';
+export { default as LiveLeaderboard } from './LiveLeaderboard';

--- a/frontend/src/components/live-performance/types.ts
+++ b/frontend/src/components/live-performance/types.ts
@@ -1,0 +1,26 @@
+export interface LiveTipEvent {
+  id: string;
+  tipperName: string;
+  amount: number;
+  asset: string;
+  createdAt: string;
+  isLargeTip: boolean;
+}
+
+export interface LeaderboardEntry {
+  tipperName: string;
+  total: number;
+  tipCount: number;
+}
+
+export interface LiveSessionState {
+  artistId: string;
+  isSessionActive: boolean;
+  privacyMode: boolean;
+  sessionStartedAt: string | null;
+  sessionTotalXlm: number;
+  tipCount: number;
+  hypeScore: number;
+  alerts: LiveTipEvent[];
+  leaderboard: LeaderboardEntry[];
+}


### PR DESCRIPTION
close #154 
close #99 
close #100 
close #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Live Performance Mode page with new "Live Mode" navigation item
  * Real-time tip tracking displays session totals, tip count, and hype meter
  * Live leaderboard shows top 5 session tippers
  * Privacy mode masks sensitive tipper information
  * Large tip notifications with visual effects
  * Artist room management with session start/stop/reset controls
  * Fullscreen view support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->