### PR TITLE
feat(contracts): implement on-chain track access control

### DIFF
--- a/contracts/track_access_control/Cargo.toml
+++ b/contracts/track_access_control/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "track_access_control"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = "0.7.0"  # ensure latest Soroban SDK

--- a/contracts/track_access_control/src/error.rs
+++ b/contracts/track_access_control/src/error.rs
@@ -1,0 +1,10 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Error {
+    Unauthorized = 1,
+    TipTooLow = 2,
+    TrackNotFound = 3,
+    AlreadyUnlocked = 4,
+}

--- a/contracts/track_access_control/src/lib.rs
+++ b/contracts/track_access_control/src/lib.rs
@@ -1,0 +1,135 @@
+#![no_std]
+
+use soroban_sdk::{contractimpl, Address, Env, Symbol, Map};
+mod error;
+use error::Error;
+
+#[derive(Clone)]
+pub struct TrackAccess {
+    pub track_id: String,
+    pub artist: Address,
+    pub min_tip_amount: i128,
+    pub is_gated: bool,
+    pub total_unlocks: u32,
+    pub created_at: u64,
+}
+
+#[derive(Clone)]
+pub struct AccessGrant {
+    pub track_id: String,
+    pub listener: Address,
+    pub unlocked_at: u64,
+    pub tip_amount_paid: i128,
+}
+
+pub struct TrackAccessControl;
+
+#[contractimpl]
+impl TrackAccessControl {
+
+    // Storage keys
+    fn track_key(track_id: &String) -> Symbol {
+        Symbol::short(&format!("track_{}", track_id))
+    }
+
+    fn grant_key(track_id: &String, listener: &Address) -> Symbol {
+        Symbol::short(&format!("grant_{}_{}", track_id, listener))
+    }
+
+    /// Artist sets a track gate
+    pub fn set_track_access(env: Env, artist: Address, track_id: String, min_tip_amount: i128) -> Result<(), Error> {
+        let caller = env.invoker();
+        if caller != artist {
+            return Err(Error::Unauthorized);
+        }
+
+        let track = TrackAccess {
+            track_id: track_id.clone(),
+            artist: artist.clone(),
+            min_tip_amount,
+            is_gated: true,
+            total_unlocks: 0,
+            created_at: env.ledger().timestamp(),
+        };
+
+        env.storage().set(&Self::track_key(&track_id), &track);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::short("TrackGateSet"),),
+            (track_id.clone(), min_tip_amount),
+        );
+
+        Ok(())
+    }
+
+    /// Unlock a track by tipping
+    pub fn unlock_track(env: Env, listener: Address, track_id: String, tip_amount: i128) -> Result<bool, Error> {
+        let mut track: TrackAccess = env
+            .storage()
+            .get(&Self::track_key(&track_id))
+            .ok_or(Error::TrackNotFound)?;
+
+        // Check tip meets minimum
+        if tip_amount < track.min_tip_amount {
+            return Err(Error::TipTooLow);
+        }
+
+        // Check if already unlocked
+        let grant_key = Self::grant_key(&track_id, &listener);
+        if env.storage().has(&grant_key) {
+            return Err(Error::AlreadyUnlocked);
+        }
+
+        // Save AccessGrant
+        let grant = AccessGrant {
+            track_id: track_id.clone(),
+            listener: listener.clone(),
+            unlocked_at: env.ledger().timestamp(),
+            tip_amount_paid: tip_amount,
+        };
+
+        env.storage().set(&grant_key, &grant);
+
+        // Update track unlock count
+        track.total_unlocks += 1;
+        env.storage().set(&Self::track_key(&track_id), &track);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::short("TrackUnlocked"),),
+            (track_id.clone(), listener.clone(), tip_amount),
+        );
+
+        Ok(true)
+    }
+
+    /// Check if listener has access
+    pub fn check_access(env: Env, listener: Address, track_id: String) -> bool {
+        let grant_key = Self::grant_key(&track_id, &listener);
+        env.storage().has(&grant_key)
+    }
+
+    /// Remove a track gate
+    pub fn remove_gate(env: Env, artist: Address, track_id: String) -> Result<(), Error> {
+        let caller = env.invoker();
+        if caller != artist {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut track: TrackAccess = env
+            .storage()
+            .get(&Self::track_key(&track_id))
+            .ok_or(Error::TrackNotFound)?;
+
+        track.is_gated = false;
+        env.storage().set(&Self::track_key(&track_id), &track);
+
+        env.events().publish(
+            (Symbol::short("TrackGateRemoved"),),
+            (track_id.clone(),),
+        );
+
+        Ok(())
+    }
+}

--- a/contracts/track_access_control/tests/track_access_tests.rs
+++ b/contracts/track_access_control/tests/track_access_tests.rs
@@ -1,0 +1,26 @@
+#![cfg(test)]
+use soroban_sdk::{testutils::Env as _, Address, Env};
+use track_access_control::{TrackAccessControl, Error};
+
+#[test]
+fn test_track_gate_and_unlock() {
+    let env = Env::default();
+    let artist = Address::random(&env);
+    let listener = Address::random(&env);
+
+    // Set gate
+    TrackAccessControl::set_track_access(env.clone(), artist.clone(), "track1".to_string(), 50).unwrap();
+
+    // Unlock with insufficient tip
+    let result = TrackAccessControl::unlock_track(env.clone(), listener.clone(), "track1".to_string(), 30);
+    assert_eq!(result, Err(Error::TipTooLow));
+
+    // Unlock with sufficient tip
+    assert_eq!(TrackAccessControl::unlock_track(env.clone(), listener.clone(), "track1".to_string(), 50), Ok(true));
+
+    // Check access
+    assert!(TrackAccessControl::check_access(env.clone(), listener.clone(), "track1".to_string()));
+
+    // Remove gate
+    assert_eq!(TrackAccessControl::remove_gate(env.clone(), artist.clone(), "track1".to_string()), Ok(()));
+}


### PR DESCRIPTION
- Added TrackAccessControl Soroban contract
- Allows artists to gate tracks with a minimum tip amount
- Functions implemented:
  • set_track_access (artist-only gate setup)
  • unlock_track (listener unlocks track by tipping)
  • check_access (verifies if listener has access)
  • remove_gate (artist-only gate removal)
- Tracks total unlocks per track
- Emits events for track gating and unlocks
- Includes unit tests covering gate setup, unlocking, access check, and gate removal

closes #180 