### PR TITLE
idempotency key support implemented

### DIFF
--- a/backend/migrations/1769950000000-AddIdempotencyKeyToTips.ts
+++ b/backend/migrations/1769950000000-AddIdempotencyKeyToTips.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+export class AddIdempotencyKeyToTips1769950000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'tips',
+      new TableColumn({
+        name: 'idempotencyKey',
+        type: 'varchar',
+        length: '128',
+        isNullable: true,
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'tips',
+      new TableIndex({
+        name: 'IDX_tips_idempotencyKey',
+        columnNames: ['idempotencyKey'],
+        isUnique: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('tips', 'IDX_tips_idempotencyKey');
+    await queryRunner.dropColumn('tips', 'idempotencyKey');
+  }
+}

--- a/backend/src/tips/create-tips.dto.ts
+++ b/backend/src/tips/create-tips.dto.ts
@@ -1,4 +1,4 @@
-import { IsUUID, IsOptional, IsString } from 'class-validator';
+import { IsUUID, IsOptional, IsString, MaxLength } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SanitiseAsPlainText } from '../common/utils/sanitise.util';
 
@@ -26,4 +26,13 @@ export class CreateTipDto {
   @IsString()
   @SanitiseAsPlainText()
   message?: string;
+
+  @ApiPropertyOptional({
+    description: 'Client-supplied idempotency key (UUID or opaque string, max 128 chars). Re-submitting with the same key returns the original tip instead of creating a duplicate.',
+    example: '550e8400-e29b-41d4-a716-446655440099',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  idempotencyKey?: string;
 }

--- a/backend/src/tips/entities/tip.entity.ts
+++ b/backend/src/tips/entities/tip.entity.ts
@@ -47,6 +47,10 @@ export class Tip {
   @Column({ length: 64, unique: true })
   stellarTxHash: string;
 
+  @Column({ length: 128, nullable: true, unique: true })
+  @Index()
+  idempotencyKey?: string;
+
   @Column({ length: 56 })
   senderAddress: string;
 

--- a/backend/src/tips/tips.controller.ts
+++ b/backend/src/tips/tips.controller.ts
@@ -40,6 +40,11 @@ export class TipsController {
     description: 'User ID of the tipper',
     required: true,
   })
+  @ApiHeader({
+    name: 'Idempotency-Key',
+    description: 'Optional client-generated key (UUID recommended). Re-submitting with the same key returns the original tip without creating a duplicate.',
+    required: false,
+  })
   @ApiResponse({
     status: HttpStatus.CREATED,
     description: 'Tip successfully created',
@@ -56,11 +61,15 @@ export class TipsController {
   async create(
     @Body(ModerateMessagePipe) createTipDto: CreateTipDto,
     @Headers('x-user-id') userId: string,
+    @Headers('idempotency-key') idempotencyKeyHeader?: string,
   ): Promise<Tip> {
     if (!userId) {
       throw new BadRequestException('User ID header (x-user-id) is required');
     }
-    // Simple validation, in real app use AuthGuard
+    // Header takes precedence over body field; merge into DTO
+    if (idempotencyKeyHeader) {
+      createTipDto.idempotencyKey = idempotencyKeyHeader;
+    }
     return this.tipsService.create(userId, createTipDto);
   }
 

--- a/backend/src/tips/tips.service.ts
+++ b/backend/src/tips/tips.service.ts
@@ -65,7 +65,20 @@ export class TipsService {
   ) {}
 
   async create(userId: string, createTipDto: CreateTipDto): Promise<Tip> {
-    const { artistId, trackId, stellarTxHash, message } = createTipDto;
+    const { artistId, trackId, stellarTxHash, message, idempotencyKey } = createTipDto;
+
+    // --- Idempotency key check: replay the original response if key already seen ---
+    if (idempotencyKey) {
+      const existing = await this.tipRepository.findOne({
+        where: { idempotencyKey },
+      });
+      if (existing) {
+        this.logger.log(
+          `Idempotency replay for key=${idempotencyKey}, tipId=${existing.id}`,
+        );
+        return existing;
+      }
+    }
 
     const existingTip = await this.tipRepository.findOne({
       where: { stellarTxHash },
@@ -166,6 +179,7 @@ export class TipsService {
       status: TipStatus.VERIFIED,
       verifiedAt: new Date(),
       stellarTimestamp: new Date(txDetails.created_at),
+      ...(idempotencyKey ? { idempotencyKey } : {}),
     });
 
     const savedTip = await this.tipRepository.save(newTip);


### PR DESCRIPTION
closes #254

closes #256 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotency support for tip submissions. Clients can now include an optional `Idempotency-Key` header when creating tips. Resubmitting a request with the same key will return the previously created tip instead of creating a duplicate, ensuring safe retry semantics during network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->