### PR TITLE
Track Embedding: Add Migration and Unit Tests

### DIFF
--- a/backend/migrations/1711900000000-CreateEmbedViews.ts
+++ b/backend/migrations/1711900000000-CreateEmbedViews.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateEmbedViews1711900000000 implements MigrationInterface {
+  name = 'CreateEmbedViews1711900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "embed_views" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "trackId" uuid NOT NULL,
+        "referrerDomain" varchar,
+        "viewedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_embed_views" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_embed_views_trackId" ON "embed_views" ("trackId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_embed_views_referrerDomain" ON "embed_views" ("referrerDomain")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_embed_views_viewedAt" ON "embed_views" ("viewedAt" DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_embed_views_viewedAt"`);
+    await queryRunner.query(`DROP INDEX "IDX_embed_views_referrerDomain"`);
+    await queryRunner.query(`DROP INDEX "IDX_embed_views_trackId"`);
+    await queryRunner.query(`DROP TABLE "embed_views"`);
+  }
+}

--- a/backend/src/embed/embed.service.spec.ts
+++ b/backend/src/embed/embed.service.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EmbedService } from './embed.service';
+import { EmbedView } from './entities/embed-view.entity';
+
+describe('EmbedService', () => {
+  let service: EmbedService;
+  const mockRepo = {
+    save: jest.fn(),
+    find: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmbedService,
+        {
+          provide: getRepositoryToken(EmbedView),
+          useValue: mockRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EmbedService>(EmbedService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('generateEmbedToken', () => {
+    it('should return a hex string', () => {
+      const token = service.generateEmbedToken('track-123');
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('should generate different tokens for different tracks', () => {
+      const t1 = service.generateEmbedToken('track-1');
+      const t2 = service.generateEmbedToken('track-2');
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe('getOEmbed', () => {
+    it('should return valid oEmbed JSON spec', () => {
+      const result = service.getOEmbed('track-123', 'https://example.com');
+      expect(result).toHaveProperty('type', 'rich');
+      expect(result).toHaveProperty('version', '1.0');
+      expect(result).toHaveProperty('provider_name');
+      expect(result).toHaveProperty('html');
+    });
+  });
+
+  describe('getMetaTags', () => {
+    it('should include Open Graph tags', () => {
+      const result = service.getMetaTags('track-123', 'https://example.com');
+      expect(result).toHaveProperty('og:type');
+      expect(result).toHaveProperty('og:title');
+      expect(result).toHaveProperty('og:url');
+    });
+
+    it('should include Twitter Card tags', () => {
+      const result = service.getMetaTags('track-123', 'https://example.com');
+      expect(result).toHaveProperty('twitter:card');
+    });
+  });
+
+  describe('recordView', () => {
+    it('should save an embed view record', async () => {
+      mockRepo.save.mockResolvedValue({ id: '1' });
+
+      await service.recordView('track-123', 'https://blog.com/post', 'blog.com');
+
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trackId: 'track-123',
+          referrerDomain: 'blog.com',
+        }),
+      );
+    });
+  });
+
+  describe('getPlayerData', () => {
+    it('should reject invalid tokens', () => {
+      expect(() =>
+        service.getPlayerData('track-123', 'invalid-token'),
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Description
Add database migration and unit tests for the existing embed API module.

## Changes
- Add migration `1711900000000-CreateEmbedViews.ts` creating embed_views table with indexes on trackId, referrerDomain, viewedAt
- Add `embed.service.spec.ts` with unit tests covering:
  - Token generation (hex format, uniqueness)
  - oEmbed response (valid spec)
  - Meta tags (Open Graph + Twitter Card)
  - View recording
  - Player data token validation

## How to test
- `cd backend && npx jest embed`

Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for embedded content views, capturing view timestamps and referrer domain information for analytics purposes.

* **Tests**
  * Added comprehensive test suite for embed service to verify token generation, oEmbed responses, and metadata tag generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->