### PR TITLE
Register Artist Subscription Tiers Module in AppModule

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -36,6 +36,7 @@ import { VersionModule } from "./version/version.module";
 import { ArtistStatusModule } from "./artist-status/artist-status.module";
 import { CustomThrottlerRedisStorage } from "./custom-throttler-storage-redis";
 import { VaryAcceptEncodingMiddleware } from "./common/middleware/vary-accept-encoding.middleware";
+import { SubscriptionsModule } from "./subscription-tiers/subscriptions.module";
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { VaryAcceptEncodingMiddleware } from "./common/middleware/vary-accept-en
     HealthModule,
     VersionModule,
     ArtistStatusModule,
+    SubscriptionsModule,
   ],
   controllers: [],
   providers: [


### PR DESCRIPTION
## Description
Wire the existing subscription-tiers module into the application.

## Changes
- Add SubscriptionsModule import to AppModule
- The module already provides all required functionality:
  - CRUD for subscription tiers
  - Subscribe, cancel, pause, resume endpoints
  - Artist subscriber listing and revenue tracking
  - Subscriber cap enforcement
  - Stellar blockchain payment integration
  - Migration and full unit test coverage (800+ lines)

## How to test
- `cd backend && npx jest subscription`
- All subscription endpoints accessible after registration

Closes #97