### PR TITLE
feat(dlq): add DLQ entity, service, migration, tests, and alert rule

### DIFF
--- a/backend/migrations/1769951000000-CreateDeadLettersTable.ts
+++ b/backend/migrations/1769951000000-CreateDeadLettersTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateDeadLettersTable1769951000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'dead_letters',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            isGenerated: true,
+          },
+          { name: 'jobType', type: 'varchar' },
+          { name: 'jobId', type: 'varchar', isNullable: true },
+          { name: 'payload', type: 'jsonb', isNullable: true },
+          { name: 'lastError', type: 'text', isNullable: true },
+          { name: 'retryCount', type: 'integer', default: '0' },
+          { name: 'recoveryMetadata', type: 'jsonb', isNullable: true },
+          { name: 'exhaustedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS IDX_dead_letters_job_type ON dead_letters ("jobType")`);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS IDX_dead_letters_exhausted_at ON dead_letters ("exhaustedAt")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('dead_letters');
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { GenresModule } from "./genres/genres.module";
 import { ActivitiesModule } from "./activities/activities.module";
 import { FollowsModule } from "./follows/follows.module";
 import { EventEmitterModule } from "@nestjs/event-emitter";
+import { QueueModule } from "./queue/queue.module";
 import { GamificationModule } from "./gamification/gamification.module";
 import { ScheduledReleasesModule } from "./scheduled-releases/scheduled-releases.module";
 import { LeaderboardsModule } from "./leaderboards/leaderboards.module";
@@ -101,6 +102,8 @@ import { validate } from "./config/env.validation";
     GamificationModule,
     EventEmitterModule.forRoot(),
     ScheduledReleasesModule,
+    // Queue module provides DLQ handling for exhausted jobs
+    QueueModule,
     LeaderboardsModule,
     ReportsModule,
     FeesModule,

--- a/backend/src/metrics/config/alert_rules.yml
+++ b/backend/src/metrics/config/alert_rules.yml
@@ -82,6 +82,16 @@ groups:
           summary: "High queue length detected"
           description: "Queue {{ $labels.queue_name }} has {{ $value }} items (threshold: 1000)"
 
+      # Dead Letter Queue Alert
+      - alert: DeadLetterQueueExhausted
+        expr: increase(dlq_exhausted_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Dead Letter Queue activity detected"
+          description: "{{ $value }} job(s) moved to DLQ in the last 5 minutes. Check dead_letters table and investigate failures."
+
       # Service Down
       - alert: ServiceDown
         expr: up == 0

--- a/backend/src/metrics/services/prometheus.service.ts
+++ b/backend/src/metrics/services/prometheus.service.ts
@@ -1,25 +1,31 @@
-import { Injectable } from '@nestjs/common';
-import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import { Injectable } from "@nestjs/common";
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+  collectDefaultMetrics,
+} from "prom-client";
 
 @Injectable()
 export class PrometheusService {
   public readonly registry: Registry;
-  
+
   // HTTP Metrics
   public readonly httpRequestDuration: Histogram;
   public readonly httpRequestTotal: Counter;
   public readonly httpRequestErrors: Counter;
-  
+
   // Database Metrics
   public readonly dbQueryDuration: Histogram;
   public readonly dbConnectionPool: Gauge;
-  
+
   // Business Metrics
   public readonly activeUsers: Gauge;
   public readonly tipsPerSecond: Counter;
   public readonly stellarTransactionSuccess: Counter;
   public readonly stellarTransactionFailure: Counter;
-  
+
   // Cache Metrics
   public readonly cacheHitTotal: Counter;
   public readonly cacheMissTotal: Counter;
@@ -39,6 +45,9 @@ export class PrometheusService {
 
   // Queue Metrics
   public readonly queueLength: Gauge;
+  // DLQ Metrics
+  public readonly dlqExhaustedTotal: Counter;
+  public readonly dlqSize: Gauge;
 
   // System Metrics
   public readonly memoryUsage: Gauge;
@@ -46,152 +55,167 @@ export class PrometheusService {
 
   constructor() {
     this.registry = new Registry();
-    
+
     // Collect default metrics (CPU, memory, etc.)
     collectDefaultMetrics({ register: this.registry });
 
     // HTTP Metrics
     this.httpRequestDuration = new Histogram({
-      name: 'http_request_duration_seconds',
-      help: 'Duration of HTTP requests in seconds',
-      labelNames: ['method', 'route', 'status_code'],
+      name: "http_request_duration_seconds",
+      help: "Duration of HTTP requests in seconds",
+      labelNames: ["method", "route", "status_code"],
       buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5],
       registers: [this.registry],
     });
 
     this.httpRequestTotal = new Counter({
-      name: 'http_requests_total',
-      help: 'Total number of HTTP requests',
-      labelNames: ['method', 'route', 'status_code'],
+      name: "http_requests_total",
+      help: "Total number of HTTP requests",
+      labelNames: ["method", "route", "status_code"],
       registers: [this.registry],
     });
 
     this.httpRequestErrors = new Counter({
-      name: 'http_request_errors_total',
-      help: 'Total number of HTTP request errors',
-      labelNames: ['method', 'route', 'error_type'],
+      name: "http_request_errors_total",
+      help: "Total number of HTTP request errors",
+      labelNames: ["method", "route", "error_type"],
       registers: [this.registry],
     });
 
     // Database Metrics
     this.dbQueryDuration = new Histogram({
-      name: 'db_query_duration_seconds',
-      help: 'Duration of database queries in seconds',
-      labelNames: ['query_type', 'table'],
+      name: "db_query_duration_seconds",
+      help: "Duration of database queries in seconds",
+      labelNames: ["query_type", "table"],
       buckets: [0.001, 0.01, 0.05, 0.1, 0.5, 1],
       registers: [this.registry],
     });
 
     this.dbConnectionPool = new Gauge({
-      name: 'db_connection_pool_size',
-      help: 'Current database connection pool size',
-      labelNames: ['state'],
+      name: "db_connection_pool_size",
+      help: "Current database connection pool size",
+      labelNames: ["state"],
       registers: [this.registry],
     });
 
     // Business Metrics
     this.activeUsers = new Gauge({
-      name: 'active_users_total',
-      help: 'Number of currently active users',
+      name: "active_users_total",
+      help: "Number of currently active users",
       registers: [this.registry],
     });
 
     this.tipsPerSecond = new Counter({
-      name: 'tips_total',
-      help: 'Total number of tips processed',
-      labelNames: ['currency', 'status'],
+      name: "tips_total",
+      help: "Total number of tips processed",
+      labelNames: ["currency", "status"],
       registers: [this.registry],
     });
 
     this.stellarTransactionSuccess = new Counter({
-      name: 'stellar_transactions_success_total',
-      help: 'Total number of successful Stellar transactions',
-      labelNames: ['operation_type'],
+      name: "stellar_transactions_success_total",
+      help: "Total number of successful Stellar transactions",
+      labelNames: ["operation_type"],
       registers: [this.registry],
     });
 
     this.stellarTransactionFailure = new Counter({
-      name: 'stellar_transactions_failure_total',
-      help: 'Total number of failed Stellar transactions',
-      labelNames: ['operation_type', 'error_code'],
+      name: "stellar_transactions_failure_total",
+      help: "Total number of failed Stellar transactions",
+      labelNames: ["operation_type", "error_code"],
       registers: [this.registry],
     });
 
     // Cache Metrics
     this.cacheHitTotal = new Counter({
-      name: 'cache_hit_total',
-      help: 'Total number of cache hits',
-      labelNames: ['cache_name'],
+      name: "cache_hit_total",
+      help: "Total number of cache hits",
+      labelNames: ["cache_name"],
       registers: [this.registry],
     });
 
     this.cacheMissTotal = new Counter({
-      name: 'cache_miss_total',
-      help: 'Total number of cache misses',
-      labelNames: ['cache_name'],
+      name: "cache_miss_total",
+      help: "Total number of cache misses",
+      labelNames: ["cache_name"],
       registers: [this.registry],
     });
 
     // Scheduled Job Metrics
     this.scheduledJobDuration = new Histogram({
-      name: 'scheduled_job_duration_seconds',
-      help: 'Duration of scheduled jobs in seconds',
-      labelNames: ['job_name', 'status'],
+      name: "scheduled_job_duration_seconds",
+      help: "Duration of scheduled jobs in seconds",
+      labelNames: ["job_name", "status"],
       buckets: [0.1, 0.5, 1, 5, 10, 30, 60],
       registers: [this.registry],
     });
 
     this.scheduledJobTotal = new Counter({
-      name: 'scheduled_job_total',
-      help: 'Total number of scheduled job executions',
-      labelNames: ['job_name', 'status'],
+      name: "scheduled_job_total",
+      help: "Total number of scheduled job executions",
+      labelNames: ["job_name", "status"],
       registers: [this.registry],
     });
 
     // Search Metrics
     this.searchQueryDuration = new Histogram({
-      name: 'search_query_duration_seconds',
-      help: 'Duration of search queries in seconds',
-      labelNames: ['query_type'],
+      name: "search_query_duration_seconds",
+      help: "Duration of search queries in seconds",
+      labelNames: ["query_type"],
       buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5],
       registers: [this.registry],
     });
 
     // Notification Metrics
     this.notificationsSent = new Counter({
-      name: 'notifications_sent_total',
-      help: 'Total number of notifications sent',
-      labelNames: ['channel', 'status'],
+      name: "notifications_sent_total",
+      help: "Total number of notifications sent",
+      labelNames: ["channel", "status"],
       registers: [this.registry],
     });
 
     // Verification Metrics
     this.artistVerificationTotal = new Counter({
-      name: 'artist_verification_total',
-      help: 'Total number of artist verification attempts',
-      labelNames: ['outcome'],
+      name: "artist_verification_total",
+      help: "Total number of artist verification attempts",
+      labelNames: ["outcome"],
       registers: [this.registry],
     });
 
     // Queue Metrics
     this.queueLength = new Gauge({
-      name: 'queue_length',
-      help: 'Current length of processing queues',
-      labelNames: ['queue_name'],
+      name: "queue_length",
+      help: "Current length of processing queues",
+      labelNames: ["queue_name"],
+      registers: [this.registry],
+    });
+
+    // DLQ Metrics
+    this.dlqExhaustedTotal = new Counter({
+      name: "dlq_exhausted_total",
+      help: "Total number of jobs exhausted and moved to DLQ",
+      labelNames: ["job_type"],
+      registers: [this.registry],
+    });
+
+    this.dlqSize = new Gauge({
+      name: "dlq_size",
+      help: "Current number of entries in DLQ",
+      labelNames: ["job_type"],
       registers: [this.registry],
     });
 
     // System Metrics
     this.memoryUsage = new Gauge({
-      name: 'app_memory_usage_bytes',
-      help: 'Application memory usage in bytes',
-      labelNames: ['type'],
+      name: "app_memory_usage_bytes",
+      help: "Application memory usage in bytes",
+      labelNames: ["type"],
       registers: [this.registry],
     });
 
     this.cpuUsage = new Gauge({
-      name: 'app_cpu_usage_percent',
-      help: 'Application CPU usage percentage',
+      name: "app_cpu_usage_percent",
+      help: "Application CPU usage percentage",
       registers: [this.registry],
     });
 
@@ -201,10 +225,10 @@ export class PrometheusService {
   private startSystemMetricsCollection() {
     setInterval(() => {
       const usage = process.memoryUsage();
-      this.memoryUsage.set({ type: 'heap_used' }, usage.heapUsed);
-      this.memoryUsage.set({ type: 'heap_total' }, usage.heapTotal);
-      this.memoryUsage.set({ type: 'rss' }, usage.rss);
-      this.memoryUsage.set({ type: 'external' }, usage.external);
+      this.memoryUsage.set({ type: "heap_used" }, usage.heapUsed);
+      this.memoryUsage.set({ type: "heap_total" }, usage.heapTotal);
+      this.memoryUsage.set({ type: "rss" }, usage.rss);
+      this.memoryUsage.set({ type: "external" }, usage.external);
     }, 5000);
   }
 

--- a/backend/src/queue/dlq.service.ts
+++ b/backend/src/queue/dlq.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { DeadLetter } from "./entities/dead-letter.entity";
+import { PrometheusService } from "../metrics/services/prometheus.service";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+
+@Injectable()
+export class DlqService {
+  private readonly logger = new Logger(DlqService.name);
+
+  constructor(
+    @InjectRepository(DeadLetter)
+    private readonly dlqRepo: Repository<DeadLetter>,
+    private readonly prometheus: PrometheusService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async createEntry(opts: {
+    jobType: string;
+    jobId?: string | null;
+    payload?: any;
+    lastError?: string | null;
+    retryCount?: number;
+    recoveryMetadata?: any | null;
+  }) {
+    const entry = this.dlqRepo.create({
+      jobType: opts.jobType,
+      jobId: opts.jobId ?? null,
+      payload: opts.payload ?? null,
+      lastError: opts.lastError ?? null,
+      retryCount: opts.retryCount ?? 0,
+      recoveryMetadata: opts.recoveryMetadata ?? null,
+    });
+
+    const saved = await this.dlqRepo.save(entry);
+    // Update metrics
+    try {
+      this.prometheus.dlqExhaustedTotal.inc({ job_type: opts.jobType }, 1);
+      const count = await this.dlqRepo.count();
+      this.prometheus.dlqSize.set({ job_type: opts.jobType }, count);
+    } catch (err) {
+      this.logger.error("Failed updating DLQ metrics", err);
+    }
+
+    // Emit event for alerting/consumers
+    this.eventEmitter.emit("dlq.job_exhausted", {
+      id: saved.id,
+      jobType: saved.jobType,
+      jobId: saved.jobId,
+      retryCount: saved.retryCount,
+      exhaustedAt: saved.exhaustedAt,
+    });
+
+    this.logger.warn(`Job moved to DLQ: ${saved.jobType} / ${saved.jobId}`);
+    return saved;
+  }
+
+  async countByType(jobType: string) {
+    return this.dlqRepo.count({ where: { jobType } });
+  }
+}

--- a/backend/src/queue/entities/dead-letter.entity.ts
+++ b/backend/src/queue/entities/dead-letter.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from "typeorm";
+
+@Entity("dead_letters")
+export class DeadLetter {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ type: "varchar" })
+  jobType: string;
+
+  @Column({ type: "varchar", nullable: true })
+  jobId: string | null;
+
+  @Column({ type: "jsonb", nullable: true })
+  payload: any;
+
+  @Column({ type: "text", nullable: true })
+  lastError: string | null;
+
+  @Column({ type: "int", default: 0 })
+  retryCount: number;
+
+  @Column({ type: "jsonb", nullable: true })
+  recoveryMetadata: any | null;
+
+  @CreateDateColumn()
+  exhaustedAt: Date;
+}

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DeadLetter } from "./entities/dead-letter.entity";
+import { DlqService } from "./dlq.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DeadLetter])],
+  providers: [DlqService],
+  exports: [DlqService],
+})
+export class QueueModule {}

--- a/backend/src/scheduled-releases/scheduled-releases.module.ts
+++ b/backend/src/scheduled-releases/scheduled-releases.module.ts
@@ -9,10 +9,12 @@ import { PreSave } from "./entities/presave.entity";
 import { Track } from "../tracks/entities/track.entity";
 import { NotificationsModule } from "../notifications/notifications.module";
 import { FollowsModule } from "../follows/follows.module";
+import { QueueModule } from "../queue/queue.module";
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ScheduledRelease, PreSave, Track]),
+    QueueModule,
     ScheduleModule.forRoot(),
     NotificationsModule,
     FollowsModule,

--- a/backend/src/scheduled-releases/scheduled-releases.service.ts
+++ b/backend/src/scheduled-releases/scheduled-releases.service.ts
@@ -7,12 +7,16 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository, LessThanOrEqual, IsNull, Not } from "typeorm";
 import { Cron, CronExpression } from "@nestjs/schedule";
-import { ScheduledRelease, ReleaseStatus } from "./entities/scheduled-release.entity";
+import {
+  ScheduledRelease,
+  ReleaseStatus,
+} from "./entities/scheduled-release.entity";
 import { PreSave } from "./entities/presave.entity";
 import { Track } from "../tracks/entities/track.entity";
 import { NotificationsService } from "../notifications/notifications.service";
 import { FollowsService } from "../follows/follows.service";
 import { NotificationType } from "@/notifications/notification.entity";
+import { DlqService } from "../queue/dlq.service";
 
 @Injectable()
 export class ScheduledReleasesService {
@@ -29,6 +33,7 @@ export class ScheduledReleasesService {
     private trackRepository: Repository<Track>,
     private notificationsService: NotificationsService,
     private followsService: FollowsService,
+    private readonly dlqService: DlqService,
   ) {}
 
   async createScheduledRelease(
@@ -169,9 +174,7 @@ export class ScheduledReleasesService {
         return;
       }
 
-      this.logger.log(
-        `Found ${releasesToPublish.length} releases to process`,
-      );
+      this.logger.log(`Found ${releasesToPublish.length} releases to process`);
 
       // Process releases with idempotency check
       for (const release of releasesToPublish) {
@@ -181,9 +184,7 @@ export class ScheduledReleasesService {
       // Clean up old failed releases
       await this.cleanupOldFailedReleases();
     } catch (error) {
-      this.logger.error(
-        `Error in scheduled release job: ${error.message}`,
-      );
+      this.logger.error(`Error in scheduled release job: ${error.message}`);
     }
   }
 
@@ -194,10 +195,7 @@ export class ScheduledReleasesService {
     release: ScheduledRelease,
   ): Promise<void> {
     // Idempotency check - skip if already processing or released
-    if (
-      release.isReleased ||
-      release.status === ReleaseStatus.PUBLISHING
-    ) {
+    if (release.isReleased || release.status === ReleaseStatus.PUBLISHING) {
       this.logger.debug(
         `Skipping release ${release.id} - already processed or publishing`,
       );
@@ -215,10 +213,7 @@ export class ScheduledReleasesService {
 
     try {
       // Mark as publishing to prevent duplicate processing
-      await this.updateReleaseStatus(
-        release.id,
-        ReleaseStatus.PUBLISHING,
-      );
+      await this.updateReleaseStatus(release.id, ReleaseStatus.PUBLISHING);
 
       this.logger.log(
         `Processing release ${release.id} (attempt ${release.retryCount + 1}/${this.maxRetries})`,
@@ -227,10 +222,7 @@ export class ScheduledReleasesService {
       await this.releaseTrack(release);
 
       // Success - mark as published
-      await this.updateReleaseStatus(
-        release.id,
-        ReleaseStatus.PUBLISHED,
-      );
+      await this.updateReleaseStatus(release.id, ReleaseStatus.PUBLISHED);
 
       this.logger.log(
         `Successfully released track ${release.track.title} (${release.trackId})`,
@@ -284,8 +276,21 @@ export class ScheduledReleasesService {
       failedAt: new Date(),
     });
 
+    // Push to DLQ with recovery metadata
+    await this.dlqService.createEntry({
+      jobType: "scheduled_release",
+      jobId: release.id,
+      payload: { trackId: release.trackId, releaseDate: release.releaseDate },
+      lastError: `Failed after ${this.maxRetries} attempts`,
+      retryCount: release.retryCount,
+      recoveryMetadata: {
+        statusBefore: release.status,
+        nextRetryAt: release.nextRetryAt ?? null,
+      },
+    });
+
     this.logger.error(
-      `Release ${release.id} marked as permanently failed`,
+      `Release ${release.id} marked as permanently failed and moved to DLQ`,
     );
   }
 
@@ -306,9 +311,7 @@ export class ScheduledReleasesService {
    * Clean up old failed releases (older than 30 days)
    */
   private async cleanupOldFailedReleases(): Promise<void> {
-    const thirtyDaysAgo = new Date(
-      Date.now() - 30 * 24 * 60 * 60 * 1000,
-    );
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
     const oldFailedReleases = await this.scheduledReleaseRepository.find({
       where: {
@@ -365,9 +368,7 @@ export class ScheduledReleasesService {
     release.publishedAt = new Date();
     await this.scheduledReleaseRepository.save(release);
 
-    this.logger.log(
-      `Release ${release.id} marked as released`,
-    );
+    this.logger.log(`Release ${release.id} marked as released`);
 
     // Notify pre-savers (with error handling)
     try {

--- a/backend/src/waveform/waveform.module.ts
+++ b/backend/src/waveform/waveform.module.ts
@@ -1,13 +1,18 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { TrackWaveform } from './entities/track-waveform.entity';
-import { WaveformService } from './waveform.service';
-import { WaveformController } from './waveform.controller';
-import { WaveformGeneratorService } from './waveform-generator.service';
-import { TracksModule } from '../tracks/tracks.module';
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { TrackWaveform } from "./entities/track-waveform.entity";
+import { WaveformService } from "./waveform.service";
+import { WaveformController } from "./waveform.controller";
+import { WaveformGeneratorService } from "./waveform-generator.service";
+import { TracksModule } from "../tracks/tracks.module";
+import { QueueModule } from "../queue/queue.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([TrackWaveform]), TracksModule],
+  imports: [
+    TypeOrmModule.forFeature([TrackWaveform]),
+    QueueModule,
+    TracksModule,
+  ],
   controllers: [WaveformController],
   providers: [WaveformService, WaveformGeneratorService],
   exports: [WaveformService],

--- a/backend/src/waveform/waveform.service.ts
+++ b/backend/src/waveform/waveform.service.ts
@@ -1,8 +1,12 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { TrackWaveform, GenerationStatus } from './entities/track-waveform.entity';
-import { WaveformGeneratorService } from './waveform-generator.service';
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import {
+  TrackWaveform,
+  GenerationStatus,
+} from "./entities/track-waveform.entity";
+import { WaveformGeneratorService } from "./waveform-generator.service";
+import { DlqService } from "../queue/dlq.service";
 
 @Injectable()
 export class WaveformService {
@@ -13,25 +17,33 @@ export class WaveformService {
     @InjectRepository(TrackWaveform)
     private waveformRepository: Repository<TrackWaveform>,
     private generatorService: WaveformGeneratorService,
+    private readonly dlqService: DlqService,
   ) {}
 
-  async generateForTrack(trackId: string, audioFilePath: string, dataPoints: number = 200): Promise<TrackWaveform> {
+  async generateForTrack(
+    trackId: string,
+    audioFilePath: string,
+    dataPoints: number = 200,
+  ): Promise<TrackWaveform> {
     const startTime = Date.now();
-    
+
     await this.waveformRepository.upsert(
       {
         trackId,
         dataPoints,
         generationStatus: GenerationStatus.PROCESSING,
       },
-      ['trackId']
+      ["trackId"],
     );
-    
-    const waveform = await this.waveformRepository.findOne({ where: { trackId } });
+
+    const waveform = await this.waveformRepository.findOne({
+      where: { trackId },
+    });
 
     try {
-      const { waveformData, peakAmplitude } = await this.generatorService.generateWaveform(audioFilePath, dataPoints);
-      
+      const { waveformData, peakAmplitude } =
+        await this.generatorService.generateWaveform(audioFilePath, dataPoints);
+
       waveform.waveformData = waveformData;
       waveform.peakAmplitude = peakAmplitude;
       waveform.generationStatus = GenerationStatus.COMPLETED;
@@ -40,22 +52,39 @@ export class WaveformService {
 
       return await this.waveformRepository.save(waveform);
     } catch (error) {
-      this.logger.error(`Waveform generation failed for track ${trackId}: ${error.message}`);
-      
+      this.logger.error(
+        `Waveform generation failed for track ${trackId}: ${error.message}`,
+      );
+
       waveform.retryCount = (waveform.retryCount || 0) + 1;
-      waveform.generationStatus = waveform.retryCount > this.MAX_RETRIES 
-        ? GenerationStatus.FAILED 
+      const exhausted = waveform.retryCount > this.MAX_RETRIES;
+      waveform.generationStatus = exhausted
+        ? GenerationStatus.FAILED
         : GenerationStatus.PENDING;
-      
+
       await this.waveformRepository.save(waveform);
 
-      if (waveform.retryCount <= this.MAX_RETRIES) {
+      if (!exhausted) {
         // TODO: Replace with durable job queue (Bull/BullMQ)
         setTimeout(() => {
-          this.generateForTrack(trackId, audioFilePath, dataPoints).catch(err => {
-            this.logger.error(`Retry failed for track ${trackId}: ${err.message}`);
-          });
+          this.generateForTrack(trackId, audioFilePath, dataPoints).catch(
+            (err) => {
+              this.logger.error(
+                `Retry failed for track ${trackId}: ${err.message}`,
+              );
+            },
+          );
         }, 5000 * waveform.retryCount);
+      } else {
+        // Move exhausted job to DLQ with recovery metadata
+        await this.dlqService.createEntry({
+          jobType: "waveform_generation",
+          jobId: trackId,
+          payload: { trackId, dataPoints },
+          lastError: error.message,
+          retryCount: waveform.retryCount,
+          recoveryMetadata: { generationStatus: waveform.generationStatus },
+        });
       }
 
       throw error;
@@ -63,19 +92,23 @@ export class WaveformService {
   }
 
   async getByTrackId(trackId: string): Promise<TrackWaveform> {
-    const waveform = await this.waveformRepository.findOne({ where: { trackId } });
+    const waveform = await this.waveformRepository.findOne({
+      where: { trackId },
+    });
     if (!waveform) {
       throw new NotFoundException(`Waveform not found for track ${trackId}`);
     }
     return waveform;
   }
 
-  async getStatus(trackId: string): Promise<{ status: GenerationStatus; retryCount: number }> {
-    const waveform = await this.waveformRepository.findOne({ 
+  async getStatus(
+    trackId: string,
+  ): Promise<{ status: GenerationStatus; retryCount: number }> {
+    const waveform = await this.waveformRepository.findOne({
       where: { trackId },
-      select: ['generationStatus', 'retryCount']
+      select: ["generationStatus", "retryCount"],
     });
-    
+
     if (!waveform) {
       throw new NotFoundException(`Waveform not found for track ${trackId}`);
     }
@@ -86,14 +119,23 @@ export class WaveformService {
     };
   }
 
-  async regenerate(trackId: string, audioFilePath: string): Promise<TrackWaveform> {
-    const waveform = await this.waveformRepository.findOne({ where: { trackId } });
-    
+  async regenerate(
+    trackId: string,
+    audioFilePath: string,
+  ): Promise<TrackWaveform> {
+    const waveform = await this.waveformRepository.findOne({
+      where: { trackId },
+    });
+
     if (waveform) {
       waveform.retryCount = 0;
       await this.waveformRepository.save(waveform);
     }
 
-    return this.generateForTrack(trackId, audioFilePath, waveform?.dataPoints || 200);
+    return this.generateForTrack(
+      trackId,
+      audioFilePath,
+      waveform?.dataPoints || 200,
+    );
   }
 }

--- a/backend/test/dlq.service.spec.ts
+++ b/backend/test/dlq.service.spec.ts
@@ -1,0 +1,42 @@
+import { Test } from "@nestjs/testing";
+import { DlqService } from "../src/queue/dlq.service";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DeadLetter } from "../src/queue/entities/dead-letter.entity";
+import { PrometheusService } from "../src/metrics/services/prometheus.service";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+
+describe("DLQ Service", () => {
+  let dlqService: DlqService;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: "sqlite",
+          database: ":memory:",
+          entities: [DeadLetter],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([DeadLetter]),
+      ],
+      providers: [DlqService, PrometheusService, EventEmitter2],
+    }).compile();
+
+    dlqService = module.get(DlqService);
+  });
+
+  it("should create DLQ entry and return saved record", async () => {
+    const entry = await dlqService.createEntry({
+      jobType: "test_job",
+      jobId: "job-1",
+      payload: { foo: "bar" },
+      lastError: "boom",
+      retryCount: 3,
+      recoveryMetadata: { attempt: 3 },
+    });
+
+    expect(entry).toBeDefined();
+    expect(entry.jobType).toBe("test_job");
+    expect(entry.jobId).toBe("job-1");
+  });
+});

--- a/backend/test/scheduled-release-dlq.spec.ts
+++ b/backend/test/scheduled-release-dlq.spec.ts
@@ -1,0 +1,59 @@
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduledReleasesService } from '../src/scheduled-releases/scheduled-releases.service';
+import { ScheduledRelease } from '../src/scheduled-releases/entities/scheduled-release.entity';
+import { Track } from '../src/tracks/entities/track.entity';
+import { DeadLetter } from '../src/queue/entities/dead-letter.entity';
+import { DlqService } from '../src/queue/dlq.service';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+
+describe('Scheduled Releases -> DLQ (integration)', () => {
+  let service: ScheduledReleasesService;
+  let dlqRepo: Repository<DeadLetter>;
+  let releaseRepo: Repository<ScheduledRelease>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [ScheduledRelease, Track, DeadLetter],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([ScheduledRelease, Track, DeadLetter]),
+      ],
+      providers: [ScheduledReleasesService, DlqService],
+    }).compile();
+
+    service = moduleRef.get(ScheduledReleasesService);
+    dlqRepo = moduleRef.get<Repository<DeadLetter>>(getRepositoryToken(DeadLetter));
+    releaseRepo = moduleRef.get<Repository<ScheduledRelease>>(getRepositoryToken(ScheduledRelease));
+  });
+
+  it('moves exhausted scheduled release to DLQ with recovery metadata', async () => {
+    // create a scheduled release that is due and already at retry threshold
+    const release = releaseRepo.create({
+      trackId: 'missing-track',
+      releaseDate: new Date(Date.now() - 1000),
+      isReleased: false,
+      status: 'pending',
+      retryCount: 3, // equals maxRetries in service
+    } as any);
+
+    const saved = await releaseRepo.save(release);
+
+    // Run the cron handler which should pick up the release and move to DLQ
+    await service.handleScheduledReleases();
+
+    // Ensure DLQ entry created
+    const entries = await dlqRepo.find({ where: { jobType: 'scheduled_release' } });
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+
+    const entry = entries.find((e) => e.jobId === saved.id);
+    expect(entry).toBeDefined();
+    expect(entry.recoveryMetadata).toBeDefined();
+    expect(entry.recoveryMetadata.statusBefore).toBe('pending');
+  });
+});


### PR DESCRIPTION
# feat(dlq): add DLQ, retries, metrics, alerts, tests
closes #265 
# Short summary
Add a durable Dead Letter Queue (DLQ) so exhausted jobs are persisted, observable, and emit alert hooks.

# Key changes
- Added DLQ entity + migration: dead-letter.entity.ts, 1769951000000-CreateDeadLettersTable.ts  
- DLQ service & module: dlq.service.ts, queue.module.ts  
- Metrics: `dlq_exhausted_total`, `dlq_size` in prometheus.service.ts  
- Processor wiring (exhausted → DLQ): scheduled-releases.service.ts, waveform.service.ts  
- Alert rule: alert_rules.yml (`DeadLetterQueueExhausted`)  
- Tests: dlq.service.spec.ts, scheduled-release-dlq.spec.ts

# How to test locally
```bash
cd backend
npm install
npm test
# run the new integration test only:
npm test -- test/scheduled-release-dlq.spec.ts
# apply DB migration:
npm run migration:run
```

# Branch
`feature/dlq-retries-alerts`

# Notes
- DLQ entries include `recoveryMetadata` for remediation.  
- Follow-ups: wire DLQ for other processors (payouts, moderation), migrate retries to a durable job queue, add admin/requeue tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Dead Letter Queue system to track and persist jobs that exceed retry limits.
  * Added Prometheus metrics monitoring DLQ exhaustion by job type.
  * New critical alert rule (`DeadLetterQueueExhausted`) triggers when jobs fail after all retries.

* **Tests**
  * Added test coverage for DLQ service and integration tests validating exhausted job persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->