### PR TITLE
feat: add owner auth to set_splits and extract storage helpers for auto royalty distribution

### DIFF
--- a/contracts/auto-royalty-distribution/src/lib.rs
+++ b/contracts/auto-royalty-distribution/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
 };
 
+mod storage;
+use storage::{get_track_owner, set_track_owner};
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -17,6 +20,7 @@ pub enum Error {
     Overflow = 7,
     Underflow = 8,
     AlreadySettled = 9,
+    Unauthorized = 10,
 }
 
 /// Represents a supported asset type
@@ -63,11 +67,22 @@ pub struct AutoRoyaltyDistribution;
 #[contractimpl]
 impl AutoRoyaltyDistribution {
     /// Set up collaborator splits for a track. Percentages are in basis points (10000 = 100%).
+    /// The caller becomes the track owner on first call; subsequent calls require the same owner.
     pub fn set_splits(
         env: Env,
+        owner: Address,
         track_id: String,
         collaborators: Vec<Collaborator>,
     ) -> Result<(), Error> {
+        owner.require_auth();
+
+        // If track already has an owner, verify the caller is that owner.
+        if let Some(existing_owner) = get_track_owner(&env, &track_id) {
+            if existing_owner != owner {
+                return Err(Error::Unauthorized);
+            }
+        }
+
         if collaborators.is_empty() {
             return Err(Error::NoCollaborators);
         }
@@ -83,6 +98,9 @@ impl AutoRoyaltyDistribution {
         if total > 10000 {
             return Err(Error::TotalExceeds10000);
         }
+
+        // Record this owner for future auth checks.
+        set_track_owner(&env, &track_id, &owner);
 
         env.storage()
             .persistent()

--- a/contracts/auto-royalty-distribution/src/storage.rs
+++ b/contracts/auto-royalty-distribution/src/storage.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::{contracttype, Address, Env, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageKey {
+    TrackOwner(String),
+}
+
+pub fn get_track_owner(env: &Env, track_id: &String) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::TrackOwner(track_id.clone()))
+}
+
+pub fn set_track_owner(env: &Env, track_id: &String, owner: &Address) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::TrackOwner(track_id.clone()), owner);
+}

--- a/contracts/auto-royalty-distribution/src/test.rs
+++ b/contracts/auto-royalty-distribution/src/test.rs
@@ -6,10 +6,12 @@ use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
 #[test]
 fn test_set_splits() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_001");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
     let collab2 = Address::generate(&env);
 
@@ -23,7 +25,7 @@ fn test_set_splits() {
         percentage: 4000, // 40%
     });
 
-    client.set_splits(&track_id, &collabs);
+    client.set_splits(&owner, &track_id, &collabs);
 
     let retrieved = client.get_splits(&track_id);
     assert_eq!(retrieved.len(), 2);
@@ -34,10 +36,12 @@ fn test_set_splits() {
 #[test]
 fn test_receive_and_distribute() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_dist");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
     let collab2 = Address::generate(&env);
 
@@ -51,7 +55,7 @@ fn test_receive_and_distribute() {
         percentage: 3000, // 30%
     });
 
-    client.set_splits(&track_id, &collabs);
+    client.set_splits(&owner, &track_id, &collabs);
     let payout_id = String::from_str(&env, "payout_001");
 
     let result = client.receive_and_distribute(&track_id, &payout_id, &1000, &Asset::Native);
@@ -64,10 +68,12 @@ fn test_receive_and_distribute() {
 #[test]
 fn test_rounding_no_loss() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_round");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
     let collab2 = Address::generate(&env);
     let collab3 = Address::generate(&env);
@@ -86,7 +92,7 @@ fn test_rounding_no_loss() {
         percentage: 3334, // 33.34%
     });
 
-    client.set_splits(&track_id, &collabs);
+    client.set_splits(&owner, &track_id, &collabs);
     let payout_id = String::from_str(&env, "payout_round");
 
     let result = client.receive_and_distribute(
@@ -108,10 +114,12 @@ fn test_rounding_no_loss() {
 #[test]
 fn test_multiple_assets() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_multi_asset");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
 
     let mut collabs = Vec::new(&env);
@@ -120,7 +128,7 @@ fn test_multiple_assets() {
         percentage: 10000, // 100%
     });
 
-    client.set_splits(&track_id, &collabs);
+    client.set_splits(&owner, &track_id, &collabs);
 
     // Test with Native asset
     let native_payout = String::from_str(&env, "payout_native");
@@ -139,11 +147,13 @@ fn test_multiple_assets() {
 #[test]
 fn test_batch_distribute() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track1 = String::from_str(&env, "track_batch1");
     let track2 = String::from_str(&env, "track_batch2");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
 
     let mut collabs = Vec::new(&env);
@@ -152,8 +162,8 @@ fn test_batch_distribute() {
         percentage: 10000,
     });
 
-    client.set_splits(&track1, &collabs);
-    client.set_splits(&track2, &collabs);
+    client.set_splits(&owner, &track1, &collabs);
+    client.set_splits(&owner, &track2, &collabs);
 
     let mut batch = Vec::new(&env);
     batch.push_back((
@@ -181,10 +191,12 @@ fn test_batch_distribute() {
 #[test]
 fn test_invalid_percentage() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_invalid");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
 
     let mut collabs = Vec::new(&env);
@@ -193,17 +205,19 @@ fn test_invalid_percentage() {
         percentage: 0, // Invalid: 0%
     });
 
-    let result = client.try_set_splits(&track_id, &collabs);
+    let result = client.try_set_splits(&owner, &track_id, &collabs);
     assert_eq!(result, Err(Ok(Error::InvalidPercentage)));
 }
 
 #[test]
 fn test_total_exceeds_100() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_over100");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
     let collab2 = Address::generate(&env);
 
@@ -217,7 +231,7 @@ fn test_total_exceeds_100() {
         percentage: 5000,
     });
 
-    let result = client.try_set_splits(&track_id, &collabs);
+    let result = client.try_set_splits(&owner, &track_id, &collabs);
     assert_eq!(result, Err(Ok(Error::TotalExceeds10000)));
 }
 
@@ -236,10 +250,12 @@ fn test_track_not_found() {
 #[test]
 fn test_invalid_amount() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_inv_amt");
+    let owner = Address::generate(&env);
     let collab1 = Address::generate(&env);
 
     let mut collabs = Vec::new(&env);
@@ -248,7 +264,7 @@ fn test_invalid_amount() {
         percentage: 10000,
     });
 
-    client.set_splits(&track_id, &collabs);
+    client.set_splits(&owner, &track_id, &collabs);
     let zero_payout = String::from_str(&env, "zero_payout");
     let negative_payout = String::from_str(&env, "negative_payout");
 
@@ -263,12 +279,40 @@ fn test_invalid_amount() {
 #[test]
 fn test_no_collaborators() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
     let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
 
     let track_id = String::from_str(&env, "track_empty");
+    let owner = Address::generate(&env);
     let collabs: Vec<Collaborator> = Vec::new(&env);
 
-    let result = client.try_set_splits(&track_id, &collabs);
+    let result = client.try_set_splits(&owner, &track_id, &collabs);
     assert_eq!(result, Err(Ok(Error::NoCollaborators)));
+}
+
+#[test]
+fn test_unauthorized_owner_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AutoRoyaltyDistribution);
+    let client = AutoRoyaltyDistributionClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_auth");
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let collab = Address::generate(&env);
+
+    let mut collabs = Vec::new(&env);
+    collabs.push_back(Collaborator {
+        address: collab.clone(),
+        percentage: 10000,
+    });
+
+    // Owner sets splits first
+    client.set_splits(&owner, &track_id, &collabs);
+
+    // Attacker tries to update — must fail with Unauthorized
+    let result = client.try_set_splits(&attacker, &track_id, &collabs);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }


### PR DESCRIPTION
## Summary

- Creates `contracts/auto-royalty-distribution/src/storage.rs` with `StorageKey` enum and track-owner helpers
- Adds `Unauthorized = 10` to the `Error` enum
- Updates `set_splits` to accept an `owner: Address` parameter that calls `owner.require_auth()`; the first caller becomes the track owner and subsequent calls are gated to that owner
- Updates all existing tests to pass an `owner` and mock auth; adds `test_unauthorized_owner_update` verifying that a different address is rejected with `Error::Unauthorized`

closes #430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collaborator split modifications now require explicit owner authentication. Track ownership is recorded and enforced; unauthorized modification attempts are rejected with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->