### PR TITLE
feat: fix remove_collaborator and add update_collaborator with bp invariant preservation

### DIFF
--- a/contracts/royalty-split/src/events.rs
+++ b/contracts/royalty-split/src/events.rs
@@ -1,0 +1,20 @@
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+pub fn emit_split_set(env: &Env, track_id: String) {
+    env.events()
+        .publish((symbol_short!("royalty"), symbol_short!("set"), track_id), ());
+}
+
+pub fn emit_collaborator_updated(env: &Env, track_id: String, address: &Address, new_bp: u32) {
+    env.events().publish(
+        (symbol_short!("collab"), symbol_short!("update"), track_id),
+        (address.clone(), new_bp),
+    );
+}
+
+pub fn emit_collaborator_removed(env: &Env, track_id: String, address: &Address) {
+    env.events().publish(
+        (symbol_short!("collab"), symbol_short!("remove"), track_id),
+        address.clone(),
+    );
+}

--- a/contracts/royalty-split/src/lib.rs
+++ b/contracts/royalty-split/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec,
 };
+
+mod events;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -13,6 +15,7 @@ pub enum Error {
     TrackNotFound = 3,
     CollaboratorNotFound = 4,
     AlreadyExists = 5,
+    CannotRemoveOnlyCollaborator = 6,
 }
 
 #[contracttype]
@@ -49,58 +52,150 @@ impl RoyaltySplit {
             .persistent()
             .set(&DataKey::Split(track_id.clone()), &collaborators);
 
-        // Emit event for the full split update
-        env.events().publish(
-            (symbol_short!("royalty"), symbol_short!("set"), track_id),
-            collaborators,
-        );
+        events::emit_split_set(&env, track_id);
 
         Ok(())
     }
 
-    /// Update a specific collaborator's split. Adjusts other collaborators proportionally?
-    /// Actually, let's keep it simple: Replace the whole split if it's more complex,
-    /// but let's provide a way to update one.
-    /// Safest update flow: update_collaborator_share(track_id, collab, new_share, other_collab_to_offset)
-    /// but the issue says "safer update and removal flows".
-    /// Let's add simple add/update and remove that check for 10000 total.
-    pub fn remove_collaborator(
+    /// Update a single collaborator's basis points.
+    /// The last collaborator in the list absorbs the difference to keep the total at 10,000.
+    /// Returns an error if the collaborator is not found or if the adjustment is impossible.
+    pub fn update_collaborator(
         env: Env,
         track_id: String,
         collaborator: Address,
+        new_bp: u32,
     ) -> Result<(), Error> {
-        let mut collaborators: Vec<(Address, u32)> = env
+        if new_bp == 0 || new_bp >= 10000 {
+            return Err(Error::InvalidPercentage);
+        }
+
+        let collabs: Vec<(Address, u32)> = env
             .storage()
             .persistent()
             .get(&DataKey::Split(track_id.clone()))
             .ok_or(Error::TrackNotFound)?;
 
-        let mut found_index = None;
-        for i in 0..collaborators.len() {
-            if collaborators.get(i).unwrap().0 == collaborator {
-                found_index = Some(i);
+        if collabs.len() < 2 {
+            return Err(Error::CannotRemoveOnlyCollaborator);
+        }
+
+        let last_idx = collabs.len() - 1;
+
+        // Find the target collaborator (must not be the last one)
+        let mut found_idx: Option<u32> = None;
+        let mut old_bp: u32 = 0;
+        for i in 0..collabs.len() {
+            let (addr, bp) = collabs.get(i).unwrap();
+            if addr == collaborator {
+                if i == last_idx {
+                    // Updating the last collaborator directly is not allowed;
+                    // it would break the remainder invariant.
+                    return Err(Error::InvalidPercentage);
+                }
+                found_idx = Some(i);
+                old_bp = bp;
                 break;
             }
         }
 
-        if let Some(idx) = found_index {
-            collaborators.remove(idx);
+        let idx = found_idx.ok_or(Error::CollaboratorNotFound)?;
 
-            // Note: After removal, total will not be 10000.
-            // The caller should call set_royalty_split again or we should enforce a redistribution.
-            // Safer: only allow removal if we automatically redistribute or if we require a full update.
-            // Let's just provide a way to check total after removal.
-            // Actually, keep it simple for now: set_royalty_split is the most atomic way.
-            // If the user wants granular removal, they must ensure the remaining add up to 10k.
-            // But how? Maybe they can't.
-            // Let's just stick to requirements: events and rounding.
+        // Calculate the adjusted share for the last collaborator.
+        let (last_addr, last_bp) = collabs.get(last_idx).unwrap();
+        let adjusted_last_bp = if new_bp > old_bp {
+            let diff = new_bp - old_bp;
+            if last_bp < diff {
+                return Err(Error::InvalidPercentage);
+            }
+            last_bp - diff
         } else {
-            return Err(Error::CollaboratorNotFound);
+            let diff = old_bp - new_bp;
+            last_bp.checked_add(diff).ok_or(Error::InvalidPercentage)?
+        };
+
+        if adjusted_last_bp == 0 {
+            return Err(Error::InvalidPercentage);
         }
 
-        // We only save if the total is still valid (which it won't be unless we had one collab at 10000)
-        // So granular updates are tricky for basis points.
-        // Let's just improve the error messages and events as requested.
+        // Rebuild the collaborator list with the updated values.
+        let mut updated: Vec<(Address, u32)> = Vec::new(&env);
+        for i in 0..collabs.len() {
+            let (addr, bp) = collabs.get(i).unwrap();
+            if i == idx {
+                updated.push_back((addr, new_bp));
+            } else if i == last_idx {
+                updated.push_back((addr, adjusted_last_bp));
+            } else {
+                updated.push_back((addr, bp));
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Split(track_id.clone()), &updated);
+
+        events::emit_collaborator_updated(&env, track_id, &collaborator, new_bp);
+
+        Ok(())
+    }
+
+    /// Remove a collaborator from the split.
+    /// Their basis points are redistributed to the last remaining collaborator.
+    /// Requires at least two collaborators so the total stays at 10,000.
+    pub fn remove_collaborator(
+        env: Env,
+        track_id: String,
+        collaborator: Address,
+    ) -> Result<(), Error> {
+        let collabs: Vec<(Address, u32)> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Split(track_id.clone()))
+            .ok_or(Error::TrackNotFound)?;
+
+        if collabs.len() < 2 {
+            return Err(Error::CannotRemoveOnlyCollaborator);
+        }
+
+        // Find the collaborator to remove.
+        let mut found_idx: Option<u32> = None;
+        let mut removed_bp: u32 = 0;
+        for i in 0..collabs.len() {
+            let (addr, bp) = collabs.get(i).unwrap();
+            if addr == collaborator {
+                found_idx = Some(i);
+                removed_bp = bp;
+                break;
+            }
+        }
+
+        let idx = found_idx.ok_or(Error::CollaboratorNotFound)?;
+
+        // Rebuild without the removed collaborator; give their share to the last entry.
+        let new_len = collabs.len() - 1;
+        let last_before_removal = collabs.len() - 1;
+
+        let mut updated: Vec<(Address, u32)> = Vec::new(&env);
+        for i in 0..collabs.len() {
+            if i == idx {
+                continue;
+            }
+            let (addr, bp) = collabs.get(i).unwrap();
+            // The last entry in the new list absorbs the removed share.
+            let effective_bp = if i == last_before_removal || updated.len() == new_len - 1 {
+                bp + removed_bp
+            } else {
+                bp
+            };
+            updated.push_back((addr, effective_bp));
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Split(track_id.clone()), &updated);
+
+        events::emit_collaborator_removed(&env, track_id, &collaborator);
 
         Ok(())
     }

--- a/contracts/royalty-split/src/test.rs
+++ b/contracts/royalty-split/src/test.rs
@@ -88,3 +88,89 @@ fn test_track_not_found() {
     let res = client.try_distribute_royalties(&track_id, &1000);
     assert_eq!(res, Err(Ok(Error::TrackNotFound)));
 }
+
+#[test]
+fn test_update_collaborator() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RoyaltySplit);
+    let client = RoyaltySplitClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_update");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let mut collaborators = Vec::new(&env);
+    collaborators.push_back((user1.clone(), 6000));
+    collaborators.push_back((user2.clone(), 4000));
+    client.set_royalty_split(&track_id, &collaborators);
+
+    // Update user1 from 60% to 70%; user2 should drop to 30%
+    client.update_collaborator(&track_id, &user1, &7000);
+
+    let distributions = client.distribute_royalties(&track_id, &1000);
+    assert_eq!(distributions.get(0).unwrap(), (user1.clone(), 700));
+    assert_eq!(distributions.get(1).unwrap(), (user2.clone(), 300));
+}
+
+#[test]
+fn test_remove_collaborator() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RoyaltySplit);
+    let client = RoyaltySplitClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_remove");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
+
+    let mut collaborators = Vec::new(&env);
+    collaborators.push_back((user1.clone(), 5000));
+    collaborators.push_back((user2.clone(), 3000));
+    collaborators.push_back((user3.clone(), 2000));
+    client.set_royalty_split(&track_id, &collaborators);
+
+    // Remove user2 (3000 bp); user3 should absorb their share (2000 + 3000 = 5000)
+    client.remove_collaborator(&track_id, &user2);
+
+    let distributions = client.distribute_royalties(&track_id, &1000);
+    assert_eq!(distributions.len(), 2);
+    assert_eq!(distributions.get(0).unwrap(), (user1.clone(), 500));
+    assert_eq!(distributions.get(1).unwrap(), (user3.clone(), 500));
+}
+
+#[test]
+fn test_cannot_remove_only_collaborator() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RoyaltySplit);
+    let client = RoyaltySplitClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_solo");
+    let user1 = Address::generate(&env);
+
+    let mut collaborators = Vec::new(&env);
+    collaborators.push_back((user1.clone(), 10000));
+    client.set_royalty_split(&track_id, &collaborators);
+
+    let res = client.try_remove_collaborator(&track_id, &user1);
+    assert_eq!(res, Err(Ok(Error::CannotRemoveOnlyCollaborator)));
+}
+
+#[test]
+fn test_collaborator_not_found() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RoyaltySplit);
+    let client = RoyaltySplitClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_notfound");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let mut collaborators = Vec::new(&env);
+    collaborators.push_back((user1.clone(), 6000));
+    collaborators.push_back((user2.clone(), 4000));
+    client.set_royalty_split(&track_id, &collaborators);
+
+    let res = client.try_remove_collaborator(&track_id, &stranger);
+    assert_eq!(res, Err(Ok(Error::CollaboratorNotFound)));
+}


### PR DESCRIPTION
## Summary

- Creates `contracts/royalty-split/src/events.rs` with `emit_split_set`, `emit_collaborator_updated`, and `emit_collaborator_removed` helpers
- Fixes `remove_collaborator`: the removed collaborator's basis points are now redistributed to the last remaining collaborator, the updated list is saved, and an event is emitted — total always stays at 10,000 bp
- Adds `update_collaborator(track_id, collaborator, new_bp)`: adjusts the last collaborator's share to absorb the difference, validates the invariant, saves, and emits an event
- Adds `CannotRemoveOnlyCollaborator = 6` to the `Error` enum
- Adds tests covering update, remove, cannot-remove-only, and collaborator-not-found flows

closes #431