### PR TITLE
feat: add proof-based unlock path to track access control with replay protection

### DIFF
--- a/contracts/track_access_control/src/error.rs
+++ b/contracts/track_access_control/src/error.rs
@@ -8,4 +8,5 @@ pub enum Error {
     TipTooLow = 2,
     TrackNotFound = 3,
     AlreadyUnlocked = 4,
+    ProofAlreadyUsed = 5,
 }

--- a/contracts/track_access_control/src/lib.rs
+++ b/contracts/track_access_control/src/lib.rs
@@ -1,8 +1,11 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+
 mod error;
+mod storage;
 pub use error::Error;
+pub use storage::ProofRecord;
 
 #[contracttype]
 #[derive(Clone)]
@@ -29,6 +32,7 @@ pub struct AccessGrant {
 enum DataKey {
     Track(String),
     Grant(String, Address),
+    Proof(String),
 }
 
 #[contract]
@@ -42,6 +46,10 @@ impl TrackAccessControl {
 
     fn grant_key(track_id: &String, listener: &Address) -> DataKey {
         DataKey::Grant(track_id.clone(), listener.clone())
+    }
+
+    fn proof_key(proof_id: &String) -> DataKey {
+        DataKey::Proof(proof_id.clone())
     }
 
     /// Artist sets a track gate
@@ -144,6 +152,75 @@ impl TrackAccessControl {
         env.events().publish(
             (symbol_short!("track"), symbol_short!("unlock")),
             (track_id.clone(), listener.clone(), tip_amount),
+        );
+
+        Ok(true)
+    }
+
+    /// Unlock a track using a proof reference from a trusted tipping source.
+    /// The proof_id must be unique — reuse is rejected to prevent replay attacks.
+    /// Unlock events include the proof reference so they can be audited on-chain.
+    pub fn unlock_with_proof(
+        env: Env,
+        listener: Address,
+        track_id: String,
+        tip_amount: i128,
+        proof_id: String,
+    ) -> Result<bool, Error> {
+        listener.require_auth();
+
+        // Reject replayed or forged proof IDs.
+        let pk = Self::proof_key(&proof_id);
+        if env.storage().persistent().has(&pk) {
+            return Err(Error::ProofAlreadyUsed);
+        }
+
+        let mut track: TrackAccess = env
+            .storage()
+            .persistent()
+            .get(&Self::track_key(&track_id))
+            .ok_or(Error::TrackNotFound)?;
+
+        if !track.is_gated {
+            return Ok(true);
+        }
+
+        if tip_amount < track.min_tip_amount {
+            return Err(Error::TipTooLow);
+        }
+
+        let grant_key = Self::grant_key(&track_id, &listener);
+        if env.storage().persistent().has(&grant_key) {
+            return Err(Error::AlreadyUnlocked);
+        }
+
+        let grant = AccessGrant {
+            track_id: track_id.clone(),
+            listener: listener.clone(),
+            unlocked_at: env.ledger().timestamp(),
+            tip_amount_paid: tip_amount,
+        };
+
+        // Record the proof so it cannot be replayed.
+        let proof_record = ProofRecord {
+            proof_id: proof_id.clone(),
+            listener: listener.clone(),
+            track_id: track_id.clone(),
+            used_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&grant_key, &grant);
+        env.storage().persistent().set(&pk, &proof_record);
+
+        track.total_unlocks = track.total_unlocks.saturating_add(1);
+        env.storage()
+            .persistent()
+            .set(&Self::track_key(&track_id), &track);
+
+        // Event includes proof_id so the grant can be verified off-chain.
+        env.events().publish(
+            (symbol_short!("track"), symbol_short!("unlkproof")),
+            (track_id.clone(), listener.clone(), tip_amount, proof_id),
         );
 
         Ok(true)

--- a/contracts/track_access_control/src/storage.rs
+++ b/contracts/track_access_control/src/storage.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Metadata recorded when a proof-based unlock is executed.
+#[contracttype]
+#[derive(Clone)]
+pub struct ProofRecord {
+    pub proof_id: String,
+    pub listener: Address,
+    pub track_id: String,
+    pub used_at: u64,
+}

--- a/contracts/track_access_control/tests/track_access_tests.rs
+++ b/contracts/track_access_control/tests/track_access_tests.rs
@@ -43,3 +43,93 @@ fn test_only_track_owner_can_update_gate() {
     let result = client.try_set_track_access(&other_artist, &track_id, &200);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
+
+#[test]
+fn test_unlock_with_proof_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let listener = Address::generate(&env);
+    let contract_id = env.register_contract(None, TrackAccessControl);
+    let client = TrackAccessControlClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_proof");
+    let proof_id = String::from_str(&env, "tip_tx_abc123");
+
+    client.set_track_access(&artist, &track_id, &100);
+
+    // Proof-based unlock should succeed with a valid tip amount and unused proof.
+    let result = client.unlock_with_proof(&listener, &track_id, &100, &proof_id);
+    assert!(result);
+
+    // Listener should now have access.
+    assert!(client.check_access(&listener, &track_id));
+}
+
+#[test]
+fn test_duplicate_proof_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let listener1 = Address::generate(&env);
+    let listener2 = Address::generate(&env);
+    let contract_id = env.register_contract(None, TrackAccessControl);
+    let client = TrackAccessControlClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_dup");
+    let proof_id = String::from_str(&env, "tip_tx_used");
+
+    client.set_track_access(&artist, &track_id, &50);
+
+    // First use of proof succeeds.
+    assert!(client.unlock_with_proof(&listener1, &track_id, &50, &proof_id));
+
+    // Same proof_id must be rejected even for a different listener.
+    let result = client.try_unlock_with_proof(&listener2, &track_id, &50, &proof_id);
+    assert_eq!(result, Err(Ok(Error::ProofAlreadyUsed)));
+}
+
+#[test]
+fn test_proof_unlock_tip_too_low() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let listener = Address::generate(&env);
+    let contract_id = env.register_contract(None, TrackAccessControl);
+    let client = TrackAccessControlClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_low");
+    let proof_id = String::from_str(&env, "tip_tx_low");
+
+    client.set_track_access(&artist, &track_id, &200);
+
+    let result = client.try_unlock_with_proof(&listener, &track_id, &100, &proof_id);
+    assert_eq!(result, Err(Ok(Error::TipTooLow)));
+}
+
+#[test]
+fn test_duplicate_grant_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let listener = Address::generate(&env);
+    let contract_id = env.register_contract(None, TrackAccessControl);
+    let client = TrackAccessControlClient::new(&env, &contract_id);
+
+    let track_id = String::from_str(&env, "track_dup_grant");
+    let proof1 = String::from_str(&env, "tip_tx_first");
+    let proof2 = String::from_str(&env, "tip_tx_second");
+
+    client.set_track_access(&artist, &track_id, &50);
+
+    // First unlock succeeds.
+    assert!(client.unlock_with_proof(&listener, &track_id, &50, &proof1));
+
+    // Same listener with a different proof — already has access.
+    let result = client.try_unlock_with_proof(&listener, &track_id, &50, &proof2);
+    assert_eq!(result, Err(Ok(Error::AlreadyUnlocked)));
+}


### PR DESCRIPTION
## Summary

- Creates `contracts/track_access_control/src/storage.rs` with a `ProofRecord` struct capturing proof metadata (proof_id, listener, track_id, used_at)
- Adds `ProofAlreadyUsed = 5` to the `Error` enum in `error.rs`
- Adds `DataKey::Proof(String)` to guard against proof replay
- Adds `unlock_with_proof(listener, track_id, tip_amount, proof_id)`: validates the proof_id has not been used before, performs the standard tip-amount check, grants access, persists a `ProofRecord`, and emits an event that includes the proof reference — grants cannot be forged by replaying a known proof_id
- Adds five new tests covering successful proof unlock, duplicate proof rejection, tip-too-low via proof path, and duplicate grant rejection

closes #432