### PR TITLE
feat: add escrow tracking fields and events to lottery prize and refund settlement

### DIFF
--- a/contracts/lottery/src/events.rs
+++ b/contracts/lottery/src/events.rs
@@ -1,0 +1,41 @@
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+pub fn emit_lottery_created(env: &Env, pool_id: String, artist: &Address) {
+    env.events().publish(
+        (symbol_short!("lottery"), symbol_short!("created")),
+        (pool_id, artist.clone()),
+    );
+}
+
+pub fn emit_entry(env: &Env, pool_id: String, tipper: &Address, tickets: u32, amount: i128) {
+    env.events().publish(
+        (symbol_short!("lottery"), symbol_short!("entry")),
+        (pool_id, tipper.clone(), tickets, amount),
+    );
+}
+
+pub fn emit_winner_drawn(env: &Env, pool_id: String, winner: &Address) {
+    env.events().publish(
+        (symbol_short!("lottery"), symbol_short!("winner")),
+        (pool_id, winner.clone()),
+    );
+}
+
+pub fn emit_prize_claimed(env: &Env, pool_id: String, winner: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("lottery"), symbol_short!("prize")),
+        (pool_id, winner.clone(), amount),
+    );
+}
+
+pub fn emit_refund_claimed(env: &Env, pool_id: String, tipper: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("lottery"), symbol_short!("refund")),
+        (pool_id, tipper.clone(), amount),
+    );
+}
+
+pub fn emit_cancelled(env: &Env, pool_id: String) {
+    env.events()
+        .publish((symbol_short!("lottery"), symbol_short!("cancel")), pool_id);
+}

--- a/contracts/lottery/src/lib.rs
+++ b/contracts/lottery/src/lib.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,
 };
 
+mod events;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum LotteryError {
@@ -26,6 +28,7 @@ pub struct LotteryPool {
     pub pool_id: String,
     pub artist: Address,
     pub balance: i128,
+    pub escrowed: i128,
     pub contribution_rate: u32,
     pub draw_time: u64,
     pub status: LotteryStatus,
@@ -42,6 +45,7 @@ pub struct LotteryEntry {
     pub tipper: Address,
     pub tickets: u32,
     pub tip_amount: i128,
+    pub escrowed_amount: i128,
     pub entered_at: u64,
 }
 
@@ -84,8 +88,9 @@ impl Lottery {
 
         let pool = LotteryPool {
             pool_id: pool_id.clone(),
-            artist,
+            artist: artist.clone(),
             balance: 0,
+            escrowed: 0,
             contribution_rate,
             draw_time,
             status: LotteryStatus::Open,
@@ -98,8 +103,10 @@ impl Lottery {
         env.storage()
             .persistent()
             .set(&(pool_key, pool_id.clone()), &pool);
-        pool_ids.push_back(pool_id);
+        pool_ids.push_back(pool_id.clone());
         env.storage().persistent().set(&pool_ids_key, &pool_ids);
+
+        events::emit_lottery_created(&env, pool_id, &artist);
 
         Ok(())
     }
@@ -127,9 +134,10 @@ impl Lottery {
             return Err(LotteryError::LotteryNotOpen);
         }
 
-        // Calculate contribution to pool
-        let contribution = tip_amount * (pool.contribution_rate as i128) / 100;
-        pool.balance += contribution;
+        // Calculate contribution escrowed into the prize pool
+        let escrowed = tip_amount * (pool.contribution_rate as i128) / 100;
+        pool.balance += escrowed;
+        pool.escrowed += escrowed;
 
         // Calculate tickets (1 ticket per 10 XLM)
         let tickets = (tip_amount / 10) as u32;
@@ -148,11 +156,14 @@ impl Lottery {
             tipper: tipper.clone(),
             tickets,
             tip_amount,
+            escrowed_amount: escrowed,
             entered_at: env.ledger().timestamp(),
         });
         env.storage().persistent().set(&pool_id, &entries);
 
-        env.storage().persistent().set(&(pool_key, pool_id), &pool);
+        env.storage().persistent().set(&(pool_key, pool_id.clone()), &pool);
+
+        events::emit_entry(&env, pool_id, &tipper, tickets, escrowed);
 
         Ok(tickets)
     }
@@ -200,7 +211,9 @@ impl Lottery {
         pool.winner = Some(winner_address.clone());
         pool.status = LotteryStatus::Completed;
 
-        env.storage().persistent().set(&(pool_key, pool_id), &pool);
+        env.storage().persistent().set(&(pool_key, pool_id.clone()), &pool);
+
+        events::emit_winner_drawn(&env, pool_id, &winner_address);
 
         Ok(winner_address)
     }
@@ -222,7 +235,9 @@ impl Lottery {
         pool.status = LotteryStatus::Cancelled;
         pool.cancelled_at = Some(env.ledger().timestamp());
 
-        env.storage().persistent().set(&(pool_key, pool_id), &pool);
+        env.storage().persistent().set(&(pool_key, pool_id.clone()), &pool);
+
+        events::emit_cancelled(&env, pool_id);
 
         Ok(())
     }
@@ -253,7 +268,7 @@ impl Lottery {
 
         for entry in entries.iter() {
             if entry.tipper == tipper {
-                refund_amount += entry.tip_amount * (pool.contribution_rate as i128) / 100;
+                refund_amount += entry.escrowed_amount;
                 found = true;
             } else {
                 new_entries.push_back(entry);
@@ -265,6 +280,8 @@ impl Lottery {
         }
 
         env.storage().persistent().set(&pool_id, &new_entries);
+
+        events::emit_refund_claimed(&env, pool_id, &tipper, refund_amount);
 
         Ok(refund_amount)
     }
@@ -298,11 +315,14 @@ impl Lottery {
             return Err(LotteryError::ClaimWindowExpired);
         }
 
-        let prize = pool.balance;
+        let prize = pool.escrowed;
         pool.balance = 0;
+        pool.escrowed = 0;
         pool.claimed = true;
 
-        env.storage().persistent().set(&(pool_key, pool_id), &pool);
+        env.storage().persistent().set(&(pool_key, pool_id.clone()), &pool);
+
+        events::emit_prize_claimed(&env, pool_id, &caller, prize);
 
         Ok(prize)
     }

--- a/contracts/lottery/tests/lottery_tests.rs
+++ b/contracts/lottery/tests/lottery_tests.rs
@@ -21,9 +21,9 @@ fn test_lottery_full_lifecycle() {
     // Create lottery
     client.create_lottery(&pool_id, &artist, &5, &(env.ledger().timestamp() + 100));
 
-    // Enter lottery
-    client.enter_lottery(&pool_id, &tipper1, &100); // 10 tickets
-    client.enter_lottery(&pool_id, &tipper2, &200); // 20 tickets
+    // Enter lottery — contributions are escrowed at 5% of tip_amount
+    client.enter_lottery(&pool_id, &tipper1, &100); // 10 tickets, 5 escrowed
+    client.enter_lottery(&pool_id, &tipper2, &200); // 20 tickets, 10 escrowed
 
     // Fast-forward time
     let new_time = env.ledger().timestamp() + 200;
@@ -33,11 +33,11 @@ fn test_lottery_full_lifecycle() {
     let winner = client.draw_winner(&pool_id);
     assert!(winner == tipper1 || winner == tipper2);
 
-    // Claim prize
+    // Claim prize — winner receives the full escrowed prize pool
     let prize = client.claim_prize(&pool_id, &winner);
-    assert_eq!(prize, 15); // (100 * 0.05) + (200 * 0.05) = 5 + 10 = 15
+    assert_eq!(prize, 15); // (100 * 5%) + (200 * 5%) = 5 + 10 = 15
 
-    // Try to claim again
+    // Try to claim again — must fail
     let result = client.try_claim_prize(&pool_id, &winner);
     assert!(result.is_err());
 }
@@ -54,6 +54,7 @@ fn test_lottery_cancellation_and_refund() {
     let pool_id = String::from_str(&env, "pool2");
 
     client.create_lottery(&pool_id, &artist, &10, &(env.ledger().timestamp() + 100));
+    // tipper contributes 100; 10 are escrowed (10%)
     client.enter_lottery(&pool_id, &tipper, &100);
 
     // Cancel lottery
@@ -63,9 +64,9 @@ fn test_lottery_cancellation_and_refund() {
     let enter_result = client.try_enter_lottery(&pool_id, &tipper, &100);
     assert!(enter_result.is_err());
 
-    // Claim refund
+    // Claim refund — tipper receives their escrowed 10 back
     let refund = client.claim_refund(&pool_id, &tipper);
-    assert_eq!(refund, 10); // 100 * 0.10 = 10
+    assert_eq!(refund, 10); // 100 * 10% = 10
 }
 
 #[test]
@@ -92,4 +93,56 @@ fn test_claim_window_expiry() {
 
     let result = client.try_claim_prize(&pool_id, &winner);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_escrow_balance_tracks_contributions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let tipper1 = Address::generate(&env);
+    let tipper2 = Address::generate(&env);
+
+    let client = LotteryClient::new(&env, &env.register_contract(None, Lottery));
+    let pool_id = String::from_str(&env, "pool_escrow");
+
+    // 20% contribution rate
+    client.create_lottery(&pool_id, &artist, &20, &(env.ledger().timestamp() + 100));
+
+    // Both tippers enter; escrowed amounts should be 20% of tip
+    let t1 = client.enter_lottery(&pool_id, &tipper1, &500); // 50 tickets, 100 escrowed
+    let t2 = client.enter_lottery(&pool_id, &tipper2, &1000); // 100 tickets, 200 escrowed
+    assert_eq!(t1, 50);
+    assert_eq!(t2, 100);
+
+    let new_time = env.ledger().timestamp() + 200;
+    env.ledger().with_mut(|l| l.timestamp = new_time);
+
+    let winner = client.draw_winner(&pool_id);
+    // Total escrowed prize pool = 100 + 200 = 300
+    let prize = client.claim_prize(&pool_id, &winner);
+    assert_eq!(prize, 300);
+}
+
+#[test]
+fn test_refund_returns_escrowed_amount_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let artist = Address::generate(&env);
+    let tipper = Address::generate(&env);
+
+    let client = LotteryClient::new(&env, &env.register_contract(None, Lottery));
+    let pool_id = String::from_str(&env, "pool_refund_exact");
+
+    // 25% contribution rate
+    client.create_lottery(&pool_id, &artist, &25, &(env.ledger().timestamp() + 100));
+    client.enter_lottery(&pool_id, &tipper, &400); // 400 * 25% = 100 escrowed
+
+    client.cancel_lottery(&pool_id);
+
+    // Refund must equal the escrowed portion, not the full tip
+    let refund = client.claim_refund(&pool_id, &tipper);
+    assert_eq!(refund, 100);
 }


### PR DESCRIPTION
## Summary

- Creates `contracts/lottery/src/events.rs` with emit helpers for lottery_created, entry, winner_drawn, prize_claimed, refund_claimed, and cancelled
- Adds `escrowed: i128` to `LotteryPool` and `escrowed_amount: i128` to `LotteryEntry` so prize and refund balances are tracked separately from the raw tip amounts
- `claim_prize` now pays out `pool.escrowed` (the real prize pool) and zeroes it on settlement
- `claim_refund` returns `entry.escrowed_amount` per entry (the contribution that was locked, not the full tip)
- Hooks all events into the existing lifecycle functions
- Updates existing tests to match the escrowed-amount semantics and adds two new tests covering escrow balance accumulation and exact refund amounts

closes #433