### PR TITLE
feat: consolidate frontend shell and request flows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,33 +1,15 @@
-import { useState, useCallback } from "react";
-import { Routes, Route } from "react-router-dom";
-
-import HomePage from "./pages/HomePage";
-import ExplorePage from "./pages/ExplorePage";
-import SearchPage from "./pages/SearchPage";
-import NotFoundPage from "./pages/NotFoundPage";
-import BadgesPage from "./pages/BadgesPage";
-import { LeaderboardsPage } from "./pages/LeaderboardsPage";
-import DashboardPage from "./pages/DashboardPage";
-import SettingsPage from "./pages/SettingsPage";
-import TipHistoryPage from "./pages/TipHistoryPage";
-import TipReceiptPage from "./pages/TipReceiptPage";
-import GiftReceiptPage from "./pages/GiftReceiptPage";
-import ArtistProfilePage from "./pages/ArtistProfilePage";
-
-import AppHeader from "./components/layout/AppHeader";
-import MusicPlayer, { tracks } from "./components/player/MusicPlayer";
-import { ArtistOnboarding } from "./components/ArtistOnboarding";
-import AnalyticsDashboard from "./components/analytics/AnalyticsDashboard";
-import InstallPrompt from "./components/InstallPrompt";
-import LivePerformanceMode from "./components/live-performance/LivePerformanceMode";
-import { AmbientMode } from "./components/ambient";
-
-import { PlayerProvider } from "./contexts/PlayerContext";
-
-/* Accessibility */
-import { LiveRegionProvider } from "./components/a11y/LiveRegion";
-import { SkipLink, KeyboardShortcutHelp } from "./components/a11y";
-import { useKeyboardShortcuts } from "./hooks";
+import { useState, useCallback } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import AppHeader from './components/layout/AppHeader';
+import MusicPlayer, { tracks } from './components/player/MusicPlayer';
+import InstallPrompt from './components/InstallPrompt';
+import { AmbientMode } from './components/ambient';
+import WidgetErrorBoundary from './components/common/WidgetErrorBoundary';
+import { PlayerProvider } from './contexts/PlayerContext';
+import { LiveRegionProvider } from './components/a11y/LiveRegion';
+import { SkipLink, KeyboardShortcutHelp } from './components/a11y';
+import { useKeyboardShortcuts } from './hooks';
+import { appRoutes } from './routes';
 
 function App() {
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -53,35 +35,18 @@ function App() {
             tabIndex={-1}
           >
             <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/search" element={<SearchPage />} />
-              <Route path="/explore" element={<ExplorePage />} />
-
-              <Route path="/badges" element={<BadgesPage />} />
-              <Route path="/leaderboards" element={<LeaderboardsPage />} />
-              <Route path="/dashboard" element={<DashboardPage />} />
-              <Route path="/settings" element={<SettingsPage />} />
-              <Route path="/analytics" element={<AnalyticsDashboard />} />
-
-              <Route
-                path="/artists/:artistId"
-                element={<ArtistProfilePage />}
-              />
-
-              <Route path="/tips/history" element={<TipHistoryPage />} />
-              <Route path="/tips/:tipId/receipt" element={<TipReceiptPage />} />
-              <Route path="/gifts/:giftId" element={<GiftReceiptPage />} />
-
-              <Route
-                path="/live-performance"
-                element={<LivePerformanceMode />}
-              />
-
-              <Route path="/onboarding" element={<ArtistOnboarding />} />
-              <Route path="*" element={<NotFoundPage />} />
+              {appRoutes.map((route) => (
+                <Route key={route.path} path={route.path} element={route.element} />
+              ))}
             </Routes>
 
-            <MusicPlayer tracks={tracks} />
+            <WidgetErrorBoundary
+              title="Player unavailable"
+              description="The music player hit an error. You can retry it without interrupting the current page."
+              className="mt-6"
+            >
+              <MusicPlayer tracks={tracks} />
+            </WidgetErrorBoundary>
             <AmbientMode />
           </main>
         </PlayerProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,18 +1,5 @@
-import WalletConnect from "../components/wallet/WalletConnect";
+import { homeRouteElement } from '../routes';
 
 export default function Home() {
-  return (
-    <div className="min-h-screen bg-navy text-white py-16 px-4">
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-bold mb-4 text-center">TipTune</h1>
-        <p className="text-xl text-ice-blue text-center mb-12">
-          Real-time music tips powered by Stellar
-        </p>
-        
-        <div className="mb-8">
-          <WalletConnect />
-        </div>
-      </div>
-    </div>
-  );
+  return homeRouteElement;
 }

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, { useRef } from 'react';
 import { X } from 'lucide-react';
-import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useModalA11y } from '@/hooks';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 interface ModalProps {
@@ -14,45 +14,14 @@ interface ModalProps {
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, description }) => {
     const modalRef = useRef<HTMLDivElement>(null);
     const closeButtonRef = useRef<HTMLButtonElement>(null);
-    const previousActiveElement = useRef<HTMLElement | null>(null);
     const prefersReducedMotion = useReducedMotion();
 
-    useFocusTrap(modalRef, { enabled: isOpen, initialFocus: closeButtonRef });
-
-    useEffect(() => {
-        if (isOpen) {
-            previousActiveElement.current = document.activeElement as HTMLElement;
-            document.body.style.overflow = 'hidden';
-        }
-
-        return () => {
-            document.body.style.overflow = 'unset';
-        };
-    }, [isOpen]);
-
-    useEffect(() => {
-        if (!isOpen && previousActiveElement.current) {
-            previousActiveElement.current.focus();
-        }
-    }, [isOpen]);
-
-    const handleKeyDown = useCallback(
-        (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                onClose();
-            }
-        },
-        [onClose]
-    );
-
-    useEffect(() => {
-        if (isOpen) {
-            document.addEventListener('keydown', handleKeyDown);
-        }
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [isOpen, handleKeyDown]);
+    useModalA11y({
+        isOpen,
+        containerRef: modalRef,
+        initialFocusRef: closeButtonRef,
+        onClose,
+    });
 
     const handleBackdropClick = (e: React.MouseEvent) => {
         if (e.target === e.currentTarget) {
@@ -70,16 +39,16 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, descrip
             aria-labelledby="modal-title"
             aria-describedby={description ? 'modal-description' : undefined}
         >
-            <div
+            <button
+                type="button"
                 className="fixed inset-0 bg-black/75 transition-opacity"
-                aria-hidden="true"
+                aria-label={`Dismiss ${title} modal backdrop`}
                 onClick={handleBackdropClick}
             />
 
             <div className="fixed inset-0 z-10 w-screen overflow-y-auto">
                 <div
                     className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
-                    onClick={handleBackdropClick}
                     role="presentation"
                 >
                     <div
@@ -87,7 +56,6 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, descrip
                         className={`relative transform overflow-hidden rounded-lg bg-navy-900 border border-navy-700 text-left shadow-xl sm:my-8 sm:w-full sm:max-w-lg ${
                             prefersReducedMotion ? '' : 'transition-all'
                         }`}
-                        onClick={(e) => e.stopPropagation()}
                         role="document"
                     >
                         <div className="flex items-center justify-between px-4 py-3 border-b border-navy-800">

--- a/frontend/src/components/common/WidgetErrorBoundary.test.tsx
+++ b/frontend/src/components/common/WidgetErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import WidgetErrorBoundary from './WidgetErrorBoundary';
+
+const ThrowOnRender: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+
+  return <div>Healthy widget</div>;
+};
+
+describe('WidgetErrorBoundary', () => {
+  it('renders a fallback and retries after a widget crash', async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const Example = () => {
+        const [shouldThrow, setShouldThrow] = React.useState(true);
+
+        return (
+          <div>
+            <button type="button" onClick={() => setShouldThrow(false)}>
+              Recover
+            </button>
+            <WidgetErrorBoundary>
+              <ThrowOnRender shouldThrow={shouldThrow} />
+            </WidgetErrorBoundary>
+          </div>
+        );
+      };
+
+      render(<Example />);
+      expect(screen.getByRole('alert')).toHaveTextContent(/widget temporarily unavailable/i);
+
+      await user.click(screen.getByRole('button', { name: /recover/i }));
+      await user.click(screen.getByRole('button', { name: /retry widget/i }));
+      expect(screen.getByText(/healthy widget/i)).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/frontend/src/components/common/WidgetErrorBoundary.tsx
+++ b/frontend/src/components/common/WidgetErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+interface WidgetErrorBoundaryProps {
+  children: React.ReactNode;
+  title?: string;
+  description?: string;
+  className?: string;
+}
+
+interface WidgetErrorBoundaryState {
+  hasError: boolean;
+}
+
+class WidgetErrorBoundary extends React.Component<
+  WidgetErrorBoundaryProps,
+  WidgetErrorBoundaryState
+> {
+  state: WidgetErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): WidgetErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Widget boundary captured an error.', error);
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <section
+        className={`rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-50 ${
+          this.props.className ?? ''
+        }`}
+        role="alert"
+      >
+        <h2 className="text-base font-semibold">
+          {this.props.title ?? 'Widget temporarily unavailable'}
+        </h2>
+        <p className="mt-1 text-rose-100/90">
+          {this.props.description ??
+            'A widget failed to render. Retry this surface without losing the rest of the page.'}
+        </p>
+        <button
+          type="button"
+          onClick={this.handleRetry}
+          className="mt-3 rounded-lg bg-white px-3 py-2 font-semibold text-rose-700 hover:bg-rose-50"
+        >
+          Retry widget
+        </button>
+      </section>
+    );
+  }
+}
+
+export default WidgetErrorBoundary;

--- a/frontend/src/components/common/modalA11y.test.tsx
+++ b/frontend/src/components/common/modalA11y.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import Modal from './Modal';
+import TipModal from '../tip/TipModal';
+import { LiveRegionProvider } from '../a11y/LiveRegion';
+
+const renderModal = (isOpen = true, onClose = vi.fn()) =>
+  render(
+    <Modal isOpen={isOpen} onClose={onClose} title="Example modal">
+      <div>
+        <input aria-label="Name" />
+        <button type="button">Confirm</button>
+      </div>
+    </Modal>,
+  );
+
+describe('modal accessibility behavior', () => {
+  it('moves initial focus into the shared modal shell', async () => {
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /close example modal/i })).toHaveFocus();
+    });
+  });
+
+  it('traps keyboard focus inside the modal', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    const closeButton = screen.getByRole('button', { name: /close example modal/i });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(screen.getByRole('button', { name: /confirm/i })).toHaveFocus();
+  });
+
+  it('restores focus to the trigger after closing', async () => {
+    const user = userEvent.setup();
+
+    const Example = () => {
+      const [isOpen, setIsOpen] = React.useState(false);
+
+      return (
+        <div>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Open modal
+          </button>
+          <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} title="Example modal">
+            <button type="button">Confirm</button>
+          </Modal>
+        </div>
+      );
+    };
+
+    render(<Example />);
+
+    const trigger = screen.getByRole('button', { name: /open modal/i });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: /close example modal/i }));
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it('closes the tip modal with Escape without dropping page focus behavior', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const onClose = vi.fn();
+      render(
+        <LiveRegionProvider>
+          <button type="button">Before modal</button>
+          <TipModal
+            isOpen
+            onClose={onClose}
+            artistId="artist-1"
+            artistName="Luna Waves"
+            walletBalance={{ xlm: 100, usdc: 25 }}
+          />
+        </LiveRegionProvider>,
+      );
+
+      expect(screen.getByRole('button', { name: /close tip modal/i })).toHaveFocus();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/components/requests/RequestForm.tsx
+++ b/frontend/src/components/requests/RequestForm.tsx
@@ -33,22 +33,30 @@ const RequestForm: React.FC<RequestFormProps> = ({
     );
   }, [tracks, search]);
 
+  const effectiveTrackId = trackId || filteredTracks[0]?.id || '';
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!trackId || tipAmount <= 0 || Number.isNaN(tipAmount)) return;
-    await onSubmit({ trackId, tipAmount, assetCode, message: message.trim() || undefined });
+    if (!effectiveTrackId || tipAmount <= 0 || Number.isNaN(tipAmount)) return;
+    await onSubmit({
+      trackId: effectiveTrackId,
+      tipAmount,
+      assetCode,
+      message: message.trim() || undefined,
+    });
   };
 
-  const selectedTrack = tracks.find((t) => t.id === trackId) ?? filteredTracks[0];
+  const selectedTrack = tracks.find((t) => t.id === effectiveTrackId) ?? filteredTracks[0];
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4" data-testid="song-request-form">
       {/* Track search */}
       <div className="space-y-1.5">
-        <label className="block text-sm font-medium text-slate-100">
+        <label htmlFor="song-request-track" className="block text-sm font-medium text-slate-100">
           Choose a track
         </label>
         <input
+          id="song-request-search"
           type="search"
           placeholder="Search artist's tracks..."
           value={search}
@@ -56,11 +64,15 @@ const RequestForm: React.FC<RequestFormProps> = ({
           className="w-full rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-primary-blue"
         />
         <select
-          value={selectedTrack?.id ?? ''}
+          id="song-request-track"
+          value={effectiveTrackId}
           onChange={(e) => setTrackId(e.target.value)}
           className="mt-2 w-full rounded-lg border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary-blue focus:border-primary-blue"
-          aria-label="Select track"
+          disabled={filteredTracks.length === 0}
         >
+          {filteredTracks.length === 0 && (
+            <option value="">No tracks match this search</option>
+          )}
           {filteredTracks.map((track) => (
             <option key={track.id} value={track.id}>
               {track.title}
@@ -71,11 +83,12 @@ const RequestForm: React.FC<RequestFormProps> = ({
 
       {/* Tip amount */}
       <div className="space-y-1.5">
-        <label className="block text-sm font-medium text-slate-100">
+        <label htmlFor="song-request-tip-amount" className="block text-sm font-medium text-slate-100">
           Tip amount
         </label>
         <div className="flex items-center gap-2">
           <input
+            id="song-request-tip-amount"
             type="number"
             min={0}
             step={0.1}
@@ -99,10 +112,11 @@ const RequestForm: React.FC<RequestFormProps> = ({
 
       {/* Message */}
       <div className="space-y-1.5">
-        <label className="block text-sm font-medium text-slate-100">
+        <label htmlFor="song-request-message" className="block text-sm font-medium text-slate-100">
           Message to artist (optional)
         </label>
         <textarea
+          id="song-request-message"
           rows={3}
           value={message}
           onChange={(e) => setMessage(e.target.value)}

--- a/frontend/src/components/requests/RequestQueue.tsx
+++ b/frontend/src/components/requests/RequestQueue.tsx
@@ -1,9 +1,13 @@
 import React, { useMemo } from 'react';
 import RequestCard from './RequestCard';
 import type { SongRequest } from './types';
+import type { RequestQueueFilter } from './requestStore';
 
 export interface RequestQueueProps {
   requests: SongRequest[];
+  filter: RequestQueueFilter;
+  counts: Record<RequestQueueFilter, number>;
+  onFilterChange: (filter: RequestQueueFilter) => void;
   onAccept: (id: string) => void;
   onDecline: (id: string) => void;
   onPlay: (id: string) => void;
@@ -11,35 +15,63 @@ export interface RequestQueueProps {
 
 const RequestQueue: React.FC<RequestQueueProps> = ({
   requests,
+  filter,
+  counts,
+  onFilterChange,
   onAccept,
   onDecline,
   onPlay,
 }) => {
-  const sorted = useMemo(
-    () =>
-      [...requests].sort((a, b) => b.tipAmount - a.tipAmount),
-    [requests]
-  );
-
-  if (!sorted.length) {
-    return (
-      <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-center text-sm text-slate-400">
-        No song requests yet. Tips with a request will appear here.
-      </div>
-    );
-  }
+  const sorted = useMemo(() => [...requests], [requests]);
+  const filterOptions: RequestQueueFilter[] = [
+    'all',
+    'pending',
+    'accepted',
+    'played',
+    'declined',
+    'expired',
+  ];
 
   return (
-    <div className="space-y-2" data-testid="request-queue">
-      {sorted.map((req) => (
-        <RequestCard
-          key={req.id}
-          request={req}
-          onAccept={() => onAccept(req.id)}
-          onDecline={() => onDecline(req.id)}
-          onPlay={() => onPlay(req.id)}
-        />
-      ))}
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {filterOptions.map((option) => {
+          const isActive = option === filter;
+
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onFilterChange(option)}
+              className={`rounded-full border px-3 py-1 text-xs font-medium capitalize transition ${
+                isActive
+                  ? 'border-primary-blue bg-primary-blue/15 text-primary-blue'
+                  : 'border-slate-700 bg-slate-900/70 text-slate-300 hover:border-slate-500'
+              }`}
+            >
+              {option} ({counts[option]})
+            </button>
+          );
+        })}
+      </div>
+
+      {!sorted.length ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-center text-sm text-slate-400">
+          No song requests match this view yet.
+        </div>
+      ) : (
+        <div className="space-y-2" data-testid="request-queue">
+          {sorted.map((req) => (
+            <RequestCard
+              key={req.id}
+              request={req}
+              onAccept={() => onAccept(req.id)}
+              onDecline={() => onDecline(req.id)}
+              onPlay={() => onPlay(req.id)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/requests/SongRequestModal.tsx
+++ b/frontend/src/components/requests/SongRequestModal.tsx
@@ -7,7 +7,8 @@ export interface SongRequestModalProps {
   isOpen: boolean;
   onClose: () => void;
   tracks: Track[];
-  onCreateRequest: (values: RequestFormValues) => Promise<void>;
+  onCreateRequest: (values: RequestFormValues) => Promise<boolean>;
+  isSubmitting?: boolean;
 }
 
 const SongRequestModal: React.FC<SongRequestModalProps> = ({
@@ -15,16 +16,20 @@ const SongRequestModal: React.FC<SongRequestModalProps> = ({
   onClose,
   tracks,
   onCreateRequest,
+  isSubmitting: externalSubmitting,
 }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [localSubmitting, setLocalSubmitting] = useState(false);
+  const isSubmitting = externalSubmitting ?? localSubmitting;
 
   const handleSubmit = async (values: RequestFormValues) => {
     try {
-      setIsSubmitting(true);
-      await onCreateRequest(values);
-      onClose();
+      setLocalSubmitting(true);
+      const wasCreated = await onCreateRequest(values);
+      if (wasCreated) {
+        onClose();
+      }
     } finally {
-      setIsSubmitting(false);
+      setLocalSubmitting(false);
     }
   };
 

--- a/frontend/src/components/requests/requestStore.test.ts
+++ b/frontend/src/components/requests/requestStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Track } from '@/types';
+import { createRequestStore } from './requestStore';
+
+const tracks: Track[] = [
+  {
+    id: 'track-1',
+    title: 'Starlight',
+    coverArt: 'cover-1',
+    plays: 10,
+    tips: 4,
+    artist: { id: 'artist-1', artistName: 'Luna Waves' },
+  },
+  {
+    id: 'track-2',
+    title: 'Afterglow',
+    coverArt: 'cover-2',
+    plays: 12,
+    tips: 8,
+    artist: { id: 'artist-1', artistName: 'Luna Waves' },
+  },
+];
+
+describe('requestStore', () => {
+  it('enqueues requests and keeps higher tipped pending requests first', async () => {
+    const store = createRequestStore({ artistId: 'artist-1', tracks });
+
+    await store.enqueue({ trackId: 'track-1', tipAmount: 5, assetCode: 'XLM' });
+    await store.enqueue({ trackId: 'track-2', tipAmount: 25, assetCode: 'USDC' });
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.requests.map((request) => request.trackId)).toEqual(['track-2', 'track-1']);
+    expect(snapshot.counts.pending).toBe(2);
+  });
+
+  it('blocks duplicate pending requests for the same fan and track', async () => {
+    const store = createRequestStore({ artistId: 'artist-1', tracks });
+
+    await store.enqueue({ trackId: 'track-1', tipAmount: 5, assetCode: 'XLM' });
+    const duplicateResult = await store.enqueue({ trackId: 'track-1', tipAmount: 10, assetCode: 'XLM' });
+
+    const snapshot = store.getSnapshot();
+    expect(duplicateResult).toBe(false);
+    expect(snapshot.requests).toHaveLength(1);
+    expect(snapshot.notification?.message).toMatch(/already requested this track/i);
+  });
+
+  it('updates request status and filters the visible queue', async () => {
+    const store = createRequestStore({ artistId: 'artist-1', tracks });
+
+    await store.enqueue({ trackId: 'track-1', tipAmount: 5, assetCode: 'XLM' });
+    await store.enqueue({ trackId: 'track-2', tipAmount: 15, assetCode: 'USDC' });
+
+    const [firstRequest] = store.getSnapshot().requests;
+    await store.updateStatus(firstRequest.id, 'played');
+    store.setFilter('played');
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.counts.played).toBe(1);
+    expect(snapshot.visibleRequests).toHaveLength(1);
+    expect(snapshot.visibleRequests[0]?.status).toBe('played');
+  });
+});

--- a/frontend/src/components/requests/requestStore.ts
+++ b/frontend/src/components/requests/requestStore.ts
@@ -1,0 +1,273 @@
+import { useSyncExternalStore } from 'react';
+import type { Track } from '@/types';
+import type { RequestStatus, SongRequest } from './types';
+
+export type RequestQueueFilter = 'all' | RequestStatus;
+
+export interface CreateRequestInput {
+  trackId: string;
+  tipAmount: number;
+  assetCode: 'XLM' | 'USDC';
+  message?: string;
+  fanName?: string;
+}
+
+export interface RequestStoreNotification {
+  id: string;
+  message: string;
+  type: 'success' | 'info';
+}
+
+export interface RequestStoreSnapshot {
+  filter: RequestQueueFilter;
+  isSubmitting: boolean;
+  notification: RequestStoreNotification | null;
+  requests: SongRequest[];
+  visibleRequests: SongRequest[];
+  counts: Record<RequestQueueFilter, number>;
+}
+
+interface RequestTransport {
+  enqueue: (input: CreateRequestInput) => Promise<SongRequest>;
+  updateStatus: (request: SongRequest, status: Exclude<RequestStatus, 'expired'>) => Promise<SongRequest>;
+}
+
+interface RequestStoreOptions {
+  tracks: Track[];
+  artistId: string;
+  fanName?: string;
+}
+
+const REQUEST_STATUS_PRIORITY: Record<RequestStatus, number> = {
+  pending: 0,
+  accepted: 1,
+  played: 2,
+  declined: 3,
+  expired: 4,
+};
+
+export const sortRequests = (requests: SongRequest[]): SongRequest[] =>
+  [...requests].sort((left, right) => {
+    const statusPriority =
+      REQUEST_STATUS_PRIORITY[left.status] - REQUEST_STATUS_PRIORITY[right.status];
+    if (statusPriority !== 0) {
+      return statusPriority;
+    }
+
+    if (left.tipAmount !== right.tipAmount) {
+      return right.tipAmount - left.tipAmount;
+    }
+
+    return new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+  });
+
+const buildCounts = (requests: SongRequest[]): Record<RequestQueueFilter, number> => ({
+  all: requests.length,
+  pending: requests.filter((request) => request.status === 'pending').length,
+  accepted: requests.filter((request) => request.status === 'accepted').length,
+  declined: requests.filter((request) => request.status === 'declined').length,
+  played: requests.filter((request) => request.status === 'played').length,
+  expired: requests.filter((request) => request.status === 'expired').length,
+});
+
+const filterRequests = (requests: SongRequest[], filter: RequestQueueFilter): SongRequest[] => {
+  if (filter === 'all') {
+    return requests;
+  }
+
+  return requests.filter((request) => request.status === filter);
+};
+
+const createMockRequestTransport = ({
+  tracks,
+  artistId,
+  fanName = 'You',
+}: RequestStoreOptions): RequestTransport => {
+  let nextSequence = 0;
+  const trackMap = new Map(tracks.map((track) => [track.id, track]));
+
+  return {
+    enqueue: async (input) => {
+      const track = trackMap.get(input.trackId);
+      if (!track) {
+        throw new Error('Track unavailable for requests.');
+      }
+
+      const createdAt = new Date(Date.UTC(2026, 0, 1, 12, 0, nextSequence)).toISOString();
+      const expiresAt = new Date(Date.UTC(2026, 0, 1, 13, 0, nextSequence)).toISOString();
+      nextSequence += 1;
+
+      return {
+        id: `${artistId}-request-${nextSequence}`,
+        trackId: input.trackId,
+        trackTitle: track.title,
+        tipAmount: input.tipAmount,
+        assetCode: input.assetCode,
+        fanName: input.fanName ?? fanName,
+        message: input.message,
+        createdAt,
+        expiresAt,
+        status: 'pending',
+      };
+    },
+    updateStatus: async (request, status) => ({
+      ...request,
+      status,
+    }),
+  };
+};
+
+class RequestStore {
+  private readonly transport: RequestTransport;
+
+  private readonly fanName: string;
+
+  private readonly listeners = new Set<() => void>();
+
+  private state: RequestStoreSnapshot = {
+    filter: 'all',
+    isSubmitting: false,
+    notification: null,
+    requests: [],
+    visibleRequests: [],
+    counts: buildCounts([]),
+  };
+
+  constructor(options: RequestStoreOptions) {
+    this.transport = createMockRequestTransport(options);
+    this.fanName = options.fanName ?? 'You';
+    this.recompute();
+  }
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = () => this.state;
+
+  private emit = () => {
+    this.listeners.forEach((listener) => listener());
+  };
+
+  private setState = (
+    updater:
+      | Partial<RequestStoreSnapshot>
+      | ((current: RequestStoreSnapshot) => Partial<RequestStoreSnapshot>)
+  ) => {
+    const patch = typeof updater === 'function' ? updater(this.state) : updater;
+    this.state = {
+      ...this.state,
+      ...patch,
+    };
+    this.recompute();
+    this.emit();
+  };
+
+  private recompute() {
+    const requests = sortRequests(this.state.requests);
+    this.state = {
+      ...this.state,
+      requests,
+      visibleRequests: filterRequests(requests, this.state.filter),
+      counts: buildCounts(requests),
+    };
+  }
+
+  setFilter = (filter: RequestQueueFilter) => {
+    this.setState({ filter });
+  };
+
+  dismissNotification = () => {
+    this.setState({ notification: null });
+  };
+
+  enqueue = async (input: CreateRequestInput) => {
+    const normalizedFanName = input.fanName ?? this.fanName;
+    const normalizedMessage = input.message?.trim() || undefined;
+    const hasDuplicate = this.state.requests.some(
+      (request) =>
+        request.trackId === input.trackId &&
+        request.fanName === normalizedFanName &&
+        request.status === 'pending'
+    );
+
+    if (hasDuplicate) {
+      this.setState({
+        notification: {
+          id: `notification-${Date.now()}`,
+          message: 'You have already requested this track. Please wait for the artist.',
+          type: 'info',
+        },
+      });
+      return false;
+    }
+
+    this.setState({ isSubmitting: true });
+
+    try {
+      const createdRequest = await this.transport.enqueue({
+        ...input,
+        fanName: normalizedFanName,
+        message: normalizedMessage,
+      });
+
+      this.setState((current) => ({
+        isSubmitting: false,
+        requests: [createdRequest, ...current.requests],
+        filter: current.filter === 'expired' ? 'all' : current.filter,
+        notification: {
+          id: `notification-${Date.now()}`,
+          message: 'Song request sent! Higher tips move you up the queue.',
+          type: 'success',
+        },
+      }));
+      return true;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to create song request right now.';
+      this.setState({
+        isSubmitting: false,
+        notification: {
+          id: `notification-${Date.now()}`,
+          message,
+          type: 'info',
+        },
+      });
+      return false;
+    }
+  };
+
+  updateStatus = async (id: string, status: Exclude<RequestStatus, 'expired'>) => {
+    const request = this.state.requests.find((candidate) => candidate.id === id);
+    if (!request) {
+      return;
+    }
+
+    const updatedRequest = await this.transport.updateStatus(request, status);
+    const messageByStatus: Record<Exclude<RequestStatus, 'expired'>, string> = {
+      pending: 'Request moved back to pending.',
+      accepted: 'Request accepted and kept in the queue.',
+      declined: 'Request declined.',
+      played: 'Fan has been notified that their request was played.',
+    };
+
+    this.setState((current) => ({
+      requests: current.requests.map((candidate) =>
+        candidate.id === id ? updatedRequest : candidate
+      ),
+      notification: {
+        id: `notification-${Date.now()}`,
+        message: messageByStatus[status],
+        type: status === 'accepted' || status === 'played' ? 'success' : 'info',
+      },
+    }));
+  };
+}
+
+export const createRequestStore = (options: RequestStoreOptions) => new RequestStore(options);
+
+export const useRequestStore = (store: RequestStore): RequestStoreSnapshot =>
+  useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);

--- a/frontend/src/components/tip/TipModal.tsx
+++ b/frontend/src/components/tip/TipModal.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { animated, useSpring, useTrail } from 'react-spring';
 import { X, Gift } from 'lucide-react';
-import { useVirtualKeyboard, useHaptic } from '../../hooks';
+import { useVirtualKeyboard, useHaptic, useModalA11y } from '../../hooks';
 import { useReducedMotion, getSpringConfig } from '../../utils/animationUtils';
 import { getSafeAreaInsets, setupSafeAreaInsets } from '../../utils/gestures';
 import AmountSelector from './AmountSelector';
@@ -47,6 +47,7 @@ const TipModal: React.FC<TipModalProps> = ({
     const haptic = useHaptic();
     const safeAreaRef = useRef<HTMLDivElement>(null);
     const sheetRef = useRef<HTMLDivElement>(null);
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
     const keyboardHeight = useVirtualKeyboard();
 
     // State
@@ -77,65 +78,12 @@ const TipModal: React.FC<TipModalProps> = ({
         setupSafeAreaInsets();
     }, []);
 
-    // Close modal with escape key
-    useEffect(() => {
-        if (!isOpen) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                handleClose();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        document.body.style.overflow = 'hidden';
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            document.body.style.overflow = 'unset';
-        };
-    }, [handleClose, isOpen]);
-
-    // Focus trap implementation
-    useEffect(() => {
-        if (!isOpen) return;
-
-        const handleFocusTrap = (e: KeyboardEvent) => {
-            if (e.key !== 'Tab') return;
-
-            const focusableElements = sheetRef.current?.querySelectorAll(
-                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-            );
-            
-            if (!focusableElements || focusableElements.length === 0) return;
-
-            const firstElement = focusableElements[0] as HTMLElement;
-            const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
-
-            if (e.shiftKey) {
-                if (document.activeElement === firstElement) {
-                    lastElement.focus();
-                    e.preventDefault();
-                }
-            } else {
-                if (document.activeElement === lastElement) {
-                    firstElement.focus();
-                    e.preventDefault();
-                }
-            }
-        };
-
-        document.addEventListener('keydown', handleFocusTrap);
-        // Set initial focus to the amount selector or close button
-        setTimeout(() => {
-            const firstButton = sheetRef.current?.querySelector('button');
-            if (firstButton) (firstButton as HTMLElement).focus();
-        }, 100);
-
-        return () => {
-            document.removeEventListener('keydown', handleFocusTrap);
-        };
-    }, [isOpen]);
+    useModalA11y({
+        isOpen,
+        containerRef: sheetRef,
+        initialFocusRef: closeButtonRef,
+        onClose: handleClose,
+    });
 
     const handleAmountChange = useCallback((amount: number) => {
         setTipAmount(amount);
@@ -270,6 +218,7 @@ const TipModal: React.FC<TipModalProps> = ({
                         </div>
                     </div>
                     <button
+                        ref={closeButtonRef}
                         onClick={handleClose}
                         className="p-2 hover:bg-navy/50 rounded-lg transition-colors"
                         aria-label="Close tip modal"

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { default as useApi } from './useApi';
 export { useSearch, addToSearchHistory, getSearchHistory, clearSearchHistory, getTrendingSearches } from './useSearch';
 export { default as useReducedMotion } from './useReducedMotion';
 export { default as useFocusTrap } from './useFocusTrap';
+export { default as useModalA11y } from './useModalA11y';
 export { default as useKeyboardShortcuts } from './useKeyboardShortcuts';
 export { default as useAnnouncer } from './useAnnouncer';
 export type { KeyboardShortcut } from './useKeyboardShortcuts';

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,9 +1,9 @@
 import { useEffect, useCallback, RefObject } from 'react';
-import { getFocusableElements } from '@/utils/accessibility';
+import { focusInitialElement, getFocusableElements } from '@/utils/accessibility';
 
 interface UseFocusTrapOptions {
   enabled?: boolean;
-  initialFocus?: RefObject<HTMLElement>;
+  initialFocus?: RefObject<HTMLElement | null>;
   restoreFocus?: boolean;
 }
 
@@ -50,13 +50,8 @@ export const useFocusTrap = <T extends HTMLElement>(
 
     document.addEventListener('keydown', handleKeyDown);
 
-    if (initialFocus?.current) {
-      initialFocus.current.focus();
-    } else if (containerRef.current) {
-      const focusableElements = getFocusableElements(containerRef.current);
-      if (focusableElements.length > 0) {
-        focusableElements[0].focus();
-      }
+    if (containerRef.current) {
+      focusInitialElement(containerRef.current, initialFocus?.current);
     }
 
     return () => {

--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,72 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+import { focusElement } from '@/utils/accessibility';
+import useFocusTrap from './useFocusTrap';
+
+interface UseModalA11yOptions<T extends HTMLElement> {
+  isOpen: boolean;
+  containerRef: RefObject<T>;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  onClose: () => void;
+  lockBodyScroll?: boolean;
+  restoreFocus?: boolean;
+}
+
+const useModalA11y = <T extends HTMLElement>({
+  isOpen,
+  containerRef,
+  initialFocusRef,
+  onClose,
+  lockBodyScroll = true,
+  restoreFocus = true,
+}: UseModalA11yOptions<T>) => {
+  const previousActiveElementRef = useRef<HTMLElement | null>(null);
+
+  const restorePreviousFocus = () => {
+    window.setTimeout(() => {
+      focusElement(previousActiveElementRef.current);
+    }, 0);
+  };
+
+  useFocusTrap(containerRef, {
+    enabled: isOpen,
+    initialFocus: initialFocusRef,
+    restoreFocus: false,
+  });
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      if (restoreFocus && previousActiveElementRef.current) {
+        restorePreviousFocus();
+      }
+      return;
+    }
+
+    previousActiveElementRef.current = document.activeElement as HTMLElement | null;
+    const previousOverflow = document.body.style.overflow;
+
+    if (lockBodyScroll) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (lockBodyScroll) {
+        document.body.style.overflow = previousOverflow;
+      }
+      if (restoreFocus && previousActiveElementRef.current) {
+        restorePreviousFocus();
+      }
+    };
+  }, [isOpen, lockBodyScroll, onClose, restoreFocus]);
+};
+
+export default useModalA11y;

--- a/frontend/src/pages/ArtistProfilePage.tsx
+++ b/frontend/src/pages/ArtistProfilePage.tsx
@@ -9,8 +9,8 @@ import { fetchArtistProfilePage, followArtist, unfollowArtist } from '@/services
 import { ArtistProfilePageData } from '@/types';
 import SongRequestModal from '@/components/requests/SongRequestModal';
 import RequestQueue from '@/components/requests/RequestQueue';
-import type { SongRequest } from '@/components/requests/types';
 import RequestNotification from '@/components/requests/RequestNotification';
+import { createRequestStore, useRequestStore } from '@/components/requests/requestStore';
 import {
   ComboCounter,
   ComboTimer,
@@ -33,8 +33,6 @@ const ArtistProfilePage: React.FC = () => {
   const [isFollowPending, setIsFollowPending] = useState(false);
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
-  const [requests, setRequests] = useState<SongRequest[]>([]);
-  const [notification, setNotification] = useState<string | null>(null);
   const [artistAccent, setArtistAccent] = useState<string>('#6366f1');
   const combo = useTipCombo({ windowMs: 30_000 });
 
@@ -57,6 +55,15 @@ const ArtistProfilePage: React.FC = () => {
     () => buildArtistThemeVariables(profileData?.artist.id, artistAccent),
     [profileData?.artist.id, artistAccent],
   );
+  const requestStore = useMemo(
+    () =>
+      createRequestStore({
+        artistId,
+        tracks: profileData?.tracks ?? [],
+      }),
+    [artistId, profileData?.tracks],
+  );
+  const requestState = useRequestStore(requestStore);
 
   useEffect(() => {
     loadArtist();
@@ -105,72 +112,34 @@ const ArtistProfilePage: React.FC = () => {
   };
 
   const handleCreateRequest = async ({
-    trackId,
     tipAmount,
-    assetCode,
-    message,
+    ...values
   }: {
     trackId: string;
     tipAmount: number;
     assetCode: 'XLM' | 'USDC';
     message?: string;
   }) => {
-    if (!profileData) return;
-
-    // Simple duplicate prevention: only one pending request per track from same fan name placeholder
-    const fanName = 'You';
-    const hasDuplicate = requests.some(
-      (r) =>
-        r.trackId === trackId &&
-        r.fanName === fanName &&
-        r.status === 'pending'
-    );
-    if (hasDuplicate) {
-      setNotification('You have already requested this track. Please wait for the artist.');
-      return;
-    }
-
-    const track = profileData.tracks.find((t) => t.id === trackId);
-    if (!track) return;
-
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour
-
-    const newRequest: SongRequest = {
-      id: `req_${Date.now()}`,
-      trackId,
-      trackTitle: track.title,
+    const wasCreated = await requestStore.enqueue({
+      ...values,
       tipAmount,
-      assetCode,
-      fanName,
-      createdAt: now.toISOString(),
-      expiresAt: expiresAt.toISOString(),
-      status: 'pending',
-      message,
-    };
-
-    setRequests((prev) => [newRequest, ...prev]);
-    combo.registerTip(tipAmount);
-    setNotification('Song request sent! Higher tips move you up the queue.');
+    });
+    if (wasCreated) {
+      combo.registerTip(tipAmount);
+    }
+    return wasCreated;
   };
 
   const handleAcceptRequest = (id: string) => {
-    setRequests((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status: 'accepted' } : r))
-    );
+    void requestStore.updateStatus(id, 'accepted');
   };
 
   const handleDeclineRequest = (id: string) => {
-    setRequests((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status: 'declined' } : r))
-    );
+    void requestStore.updateStatus(id, 'declined');
   };
 
   const handlePlayRequest = (id: string) => {
-    setRequests((prev) =>
-      prev.map((r) => (r.id === id ? { ...r, status: 'played' } : r))
-    );
-    setNotification('Fan has been notified that their request was played.');
+    void requestStore.updateStatus(id, 'played');
   };
 
   if (isLoading) {
@@ -298,12 +267,24 @@ const ArtistProfilePage: React.FC = () => {
               remainingMs={combo.timeRemainingMs}
             />
             <OnFireAnimation active={combo.isOnFire} />
-            {notification && (
-              <RequestNotification message={notification} type="info" />
+            {requestState.notification && (
+              <button
+                type="button"
+                onClick={requestStore.dismissNotification}
+                className="w-full text-left"
+              >
+                <RequestNotification
+                  message={requestState.notification.message}
+                  type={requestState.notification.type}
+                />
+              </button>
             )}
             <div className="mt-2">
               <RequestQueue
-                requests={requests}
+                requests={requestState.visibleRequests}
+                filter={requestState.filter}
+                counts={requestState.counts}
+                onFilterChange={requestStore.setFilter}
                 onAccept={handleAcceptRequest}
                 onDecline={handleDeclineRequest}
                 onPlay={handlePlayRequest}
@@ -347,6 +328,7 @@ const ArtistProfilePage: React.FC = () => {
         onClose={() => setIsRequestModalOpen(false)}
         tracks={profileData.tracks}
         onCreateRequest={handleCreateRequest}
+        isSubmitting={requestState.isSubmitting}
       />
     </div>
   );

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import HomePage from './pages/HomePage';
+import ExplorePage from './pages/ExplorePage';
+import SearchPage from './pages/SearchPage';
+import NotFoundPage from './pages/NotFoundPage';
+import BadgesPage from './pages/BadgesPage';
+import { LeaderboardsPage } from './pages/LeaderboardsPage';
+import DashboardPage from './pages/DashboardPage';
+import SettingsPage from './pages/SettingsPage';
+import TipHistoryPage from './pages/TipHistoryPage';
+import TipReceiptPage from './pages/TipReceiptPage';
+import GiftReceiptPage from './pages/GiftReceiptPage';
+import ArtistProfilePage from './pages/ArtistProfilePage';
+import { ArtistOnboarding } from './components/ArtistOnboarding';
+import AnalyticsDashboard from './components/analytics/AnalyticsDashboard';
+import LivePerformanceMode from './components/live-performance/LivePerformanceMode';
+import WidgetErrorBoundary from './components/common/WidgetErrorBoundary';
+
+export interface AppRouteDefinition {
+  path: string;
+  element: ReactElement;
+}
+
+export const homeRouteElement = <HomePage />;
+
+export const appRoutes: AppRouteDefinition[] = [
+  { path: '/', element: homeRouteElement },
+  { path: '/search', element: <SearchPage /> },
+  { path: '/explore', element: <ExplorePage /> },
+  { path: '/badges', element: <BadgesPage /> },
+  { path: '/leaderboards', element: <LeaderboardsPage /> },
+  { path: '/dashboard', element: <DashboardPage /> },
+  { path: '/settings', element: <SettingsPage /> },
+  {
+    path: '/analytics',
+    element: (
+      <WidgetErrorBoundary
+        title="Analytics temporarily unavailable"
+        description="One of the analytics widgets failed, so the rest of the app is still available while you retry."
+      >
+        <AnalyticsDashboard />
+      </WidgetErrorBoundary>
+    ),
+  },
+  { path: '/artists/:artistId', element: <ArtistProfilePage /> },
+  { path: '/tips/history', element: <TipHistoryPage /> },
+  { path: '/tips/:tipId/receipt', element: <TipReceiptPage /> },
+  { path: '/gifts/:giftId', element: <GiftReceiptPage /> },
+  {
+    path: '/live-performance',
+    element: (
+      <WidgetErrorBoundary
+        title="Live widgets temporarily unavailable"
+        description="The live-performance surface hit an error. Retry the live widget without reloading the whole app."
+      >
+        <LivePerformanceMode />
+      </WidgetErrorBoundary>
+    ),
+  },
+  { path: '/onboarding', element: <ArtistOnboarding /> },
+  { path: '*', element: <NotFoundPage /> },
+];

--- a/frontend/src/utils/accessibility.ts
+++ b/frontend/src/utils/accessibility.ts
@@ -57,6 +57,27 @@ export const getFocusableElements = (container: HTMLElement): HTMLElement[] => {
   );
 };
 
+export const focusElement = (element: HTMLElement | null | undefined): boolean => {
+  if (!element || typeof element.focus !== 'function') {
+    return false;
+  }
+
+  element.focus();
+  return document.activeElement === element;
+};
+
+export const focusInitialElement = (
+  container: HTMLElement,
+  preferredElement?: HTMLElement | null
+): boolean => {
+  if (focusElement(preferredElement)) {
+    return true;
+  }
+
+  const focusableElements = getFocusableElements(container);
+  return focusElement(focusableElements[0]);
+};
+
 export const trapFocus = (container: HTMLElement, event: KeyboardEvent): void => {
   const focusableElements = getFocusableElements(container);
   


### PR DESCRIPTION
## Description
Consolidates the frontend app shell around the Vite router, adds resilient widget boundaries for high-risk surfaces, centralizes modal accessibility behavior, and completes the song-request domain with a deterministic local store.

Closes #452
Closes #361
Closes #453
Closes #454

## Changes proposed

### What were you told to do?
Group four frontend issues into one PR by removing duplicate shell ownership, protecting high-risk widgets with error boundaries, standardizing modal accessibility behavior, and turning song requests into a shared local-first module with deterministic state.

### What did I do?
#### Frontend architecture and resilience
- Added `frontend/src/routes.tsx` as the single route-definition source for the Vite app and updated `frontend/src/App.tsx` to render from it.
- Reused the same home-route element from `frontend/src/app/page.tsx` so the leftover app-shell tree no longer owns a second homepage implementation.
- Added `WidgetErrorBoundary` coverage around the persistent player plus analytics and live-performance widget surfaces, with forced-error test coverage.

#### Modal accessibility and request domain
- Moved focus trapping, escape handling, body scroll lock, initial focus, and restore-focus behavior into shared modal utilities/hooks used by both `Modal.tsx` and `TipModal.tsx`.
- Added regression tests for focus trap, escape close, initial focus, and return-focus behavior in `modalA11y.test.tsx`.
- Built `requestStore.ts` as a deterministic local request domain with queue sorting, dedupe, filtering, notifications, and status transitions, then wired the artist page and request UI to that shared store.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test`
- `npm run build`
- Added explicit tests for widget-boundary fallback rendering, modal accessibility behavior, and request-store enqueue/dedupe/status/order flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error recovery for widgets; player or analytics failures no longer crash the app.
  * Introduced filtering capabilities for song requests with visual counts per filter.

* **Bug Fixes**
  * Improved form handling when no matching tracks are found.
  * Prevented duplicate pending requests for the same track.

* **Improvements**
  * Enhanced modal and form accessibility with better focus management and keyboard navigation.
  * Refined form labels and input accessibility.

* **Tests**
  * Added comprehensive test coverage for error boundaries, modals, and request management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->