### PR TITLE
feat: payout idempotency, file orphan cleanup, storage abstraction, search visibility (#504 #505 #506 #507)

### DIFF
--- a/backend/migrations/1771000001000-AddPayoutIdempotencyKey.ts
+++ b/backend/migrations/1771000001000-AddPayoutIdempotencyKey.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds an idempotencyKey column to payout_requests for replay-safe retries.
+ *
+ * The column is nullable so existing rows are not affected.
+ * A unique index ensures duplicate keys are rejected at the DB level as a
+ * last line of defence even if the application-level check is bypassed.
+ */
+export class AddPayoutIdempotencyKey1771000001000 implements MigrationInterface {
+  name = 'AddPayoutIdempotencyKey1771000001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "payout_requests"
+      ADD COLUMN IF NOT EXISTS "idempotencyKey" character varying(128) DEFAULT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_payout_requests_idempotencyKey"
+      ON "payout_requests" ("idempotencyKey")
+      WHERE "idempotencyKey" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "UQ_payout_requests_idempotencyKey"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "payout_requests"
+      DROP COLUMN IF EXISTS "idempotencyKey"
+    `);
+  }
+}

--- a/backend/src/artiste-payout/create-payout.dto.ts
+++ b/backend/src/artiste-payout/create-payout.dto.ts
@@ -3,11 +3,12 @@ import {
   IsNumber,
   IsPositive,
   IsIn,
+  IsOptional,
   Length,
   Matches,
   IsUUID,
 } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreatePayoutDto {
   @ApiProperty({ description: 'Artist ID requesting the payout' })
@@ -32,4 +33,15 @@ export class CreatePayoutDto {
   @Length(56, 56)
   @Matches(/^G[A-Z2-7]{55}$/, { message: 'Invalid Stellar address format' })
   destinationAddress: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Client-generated idempotency key (UUID v4 recommended). ' +
+      'Retrying with the same key returns the original result without creating a duplicate.',
+    example: '7f3e8d2a-1b4c-4f5e-9a0b-2c3d4e5f6a7b',
+  })
+  @IsOptional()
+  @IsString()
+  @Length(1, 128)
+  idempotencyKey?: string;
 }

--- a/backend/src/artiste-payout/payout-request.entity.ts
+++ b/backend/src/artiste-payout/payout-request.entity.ts
@@ -52,4 +52,13 @@ export class PayoutRequest {
 
   @Column({ type: 'timestamp', nullable: true })
   processedAt: Date | null;
+
+  /**
+   * Client-supplied idempotency key.
+   * The same key always replays the original result instead of creating a
+   * duplicate pending row, making retries safe.
+   */
+  @Column({ type: 'varchar', length: 128, nullable: true, unique: true })
+  @Index()
+  idempotencyKey: string | null;
 }

--- a/backend/src/artiste-payout/payouts.service.ts
+++ b/backend/src/artiste-payout/payouts.service.ts
@@ -121,7 +121,22 @@ export class PayoutsService {
     requestingUserId: string,
     dto: CreatePayoutDto,
   ): Promise<PayoutRequest> {
-    const { artistId, amount, assetCode, destinationAddress } = dto;
+    const { artistId, amount, assetCode, destinationAddress, idempotencyKey } = dto;
+
+    // Idempotency check: if a key was supplied and we already have a row for it,
+    // replay the original result without creating a duplicate pending request.
+    if (idempotencyKey) {
+      const existing = await this.payoutRepo.findOne({
+        where: { idempotencyKey },
+      });
+      if (existing) {
+        this.logger.log(
+          `Replaying idempotent payout result for key "${idempotencyKey}" (id: ${existing.id})`,
+        );
+        return existing;
+      }
+    }
+
     const artist = await this.assertArtistOwnership(requestingUserId, artistId);
 
     // 1. Minimum threshold check
@@ -197,6 +212,7 @@ export class PayoutsService {
         assetCode,
         destinationAddress,
         status: PayoutStatus.PENDING,
+        idempotencyKey: idempotencyKey ?? null,
       });
 
       const saved = await qr.manager.getRepository(PayoutRequest).save(payout);

--- a/backend/src/search/search-visibility.policy.ts
+++ b/backend/src/search/search-visibility.policy.ts
@@ -1,0 +1,91 @@
+import { SelectQueryBuilder } from 'typeorm';
+import { ArtistStatus } from '../artists/entities/artist.entity';
+
+/**
+ * Centralised visibility predicates for public search and suggestions.
+ *
+ * Apply these helpers to every query that surfaces content to unauthenticated
+ * or non-owner users.  Keeping the rules in one place means a single change
+ * propagates to all search surfaces (full-text search, suggestions, browse).
+ *
+ * Rules enforced by this policy:
+ *   Artists:
+ *     - `deletedAt IS NULL`   — hard soft-deletes must never surface
+ *     - `isDeleted = false`   — legacy soft-delete flag
+ *     - `isPublic = true`     — only publicly-discoverable profiles
+ *
+ *   Tracks:
+ *     - `deletedAt IS NULL`   — soft-deleted tracks excluded
+ *     - `isPublic = true`     — private tracks excluded
+ *     - `artist.deletedAt IS NULL` — tracks whose artist was deleted
+ *     - `artist.isDeleted = false`
+ *
+ *   Artist-status constraints (optional, for status-aware contexts):
+ *     - Records with statuses that opt out of discovery can be hidden via
+ *       `applyArtistStatusConstraint`.
+ */
+export class SearchVisibilityPolicy {
+  /**
+   * Apply public-artist visibility rules to an artist query builder.
+   * The alias parameter must match the alias used in the query builder.
+   */
+  static applyArtistVisibility<T>(
+    qb: SelectQueryBuilder<T>,
+    alias = 'artist',
+  ): SelectQueryBuilder<T> {
+    return qb
+      .andWhere(`${alias}.deletedAt IS NULL`)
+      .andWhere(`${alias}.isDeleted = :visibilityIsDeleted`, {
+        visibilityIsDeleted: false,
+      })
+      .andWhere(`${alias}.isPublic = :visibilityIsPublic`, {
+        visibilityIsPublic: true,
+      });
+  }
+
+  /**
+   * Apply public-track visibility rules to a track query builder.
+   * Pass `artistAlias` if the artist is already joined and you want to
+   * also exclude tracks whose artist is deleted/hidden.
+   */
+  static applyTrackVisibility<T>(
+    qb: SelectQueryBuilder<T>,
+    trackAlias = 'track',
+    artistAlias?: string,
+  ): SelectQueryBuilder<T> {
+    qb
+      .andWhere(`${trackAlias}.deletedAt IS NULL`)
+      .andWhere(`${trackAlias}.isPublic = :trackVisibilityIsPublic`, {
+        trackVisibilityIsPublic: true,
+      });
+
+    if (artistAlias) {
+      qb
+        .andWhere(`${artistAlias}.deletedAt IS NULL`)
+        .andWhere(`${artistAlias}.isDeleted = :trackArtistIsDeleted`, {
+          trackArtistIsDeleted: false,
+        });
+    }
+
+    return qb;
+  }
+
+  /**
+   * Optionally restrict search to specific artist status values.
+   * By default all non-deleted public artists are included.
+   * Callers can pass `excludedStatuses` to hide artists that have opted out
+   * of discovery (e.g. `ON_BREAK` or `HIATUS`).
+   */
+  static applyArtistStatusConstraint<T>(
+    qb: SelectQueryBuilder<T>,
+    alias = 'artist',
+    excludedStatuses: ArtistStatus[] = [],
+  ): SelectQueryBuilder<T> {
+    if (excludedStatuses.length > 0) {
+      qb.andWhere(`${alias}.status NOT IN (:...excludedStatuses)`, {
+        excludedStatuses,
+      });
+    }
+    return qb;
+  }
+}

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -9,6 +9,7 @@ import { ArtistStatus } from "../artist-status/entities/artist-status.entity";
 import { SearchQueryDto, SearchType, SortOption } from "./dto/search-query.dto";
 import { SearchSuggestionsQueryDto } from "./dto/search-suggestions-query.dto";
 import { PaginatedResult } from "@/events-live-show/events.service";
+import { SearchVisibilityPolicy } from "./search-visibility.policy";
 
 const SIMILARITY_THRESHOLD = 0.1;
 const FUZZY_WEIGHT = 0.5;
@@ -94,6 +95,9 @@ export class SearchService {
         "status",
         "status.showOnProfile = true",
       );
+
+    // Enforce centralised visibility rules before any other predicates
+    SearchVisibilityPolicy.applyArtistVisibility(qb, "artist");
 
     if (hasQuery) {
       if (tsQuery) {
@@ -193,6 +197,10 @@ export class SearchService {
         "status.showOnProfile = true",
       );
 
+    // Enforce centralised visibility rules — excludes deleted/private tracks
+    // and tracks whose artist is deleted or hidden
+    SearchVisibilityPolicy.applyTrackVisibility(qb, "track", "artist");
+
     if (hasQuery) {
       if (tsQuery) {
         qb.setParameter("tsQuery", tsQuery);
@@ -288,7 +296,7 @@ export class SearchService {
     const take = type ? limit : Math.ceil(limit / 2);
 
     if (!type || type === "artist") {
-      const artists = await this.artistRepo
+      const artistSuggQb = this.artistRepo
         .createQueryBuilder("artist")
         .select([
           "artist.id",
@@ -301,7 +309,12 @@ export class SearchService {
         .where(
           `(artist."artistName" ILIKE :like OR artist.genre ILIKE :like)`,
           { like },
-        )
+        );
+
+      // Apply visibility policy to suggestions — hidden/deleted artists must not appear
+      SearchVisibilityPolicy.applyArtistVisibility(artistSuggQb, "artist");
+
+      const artists = await artistSuggQb
         // Pre-sort: prefix match first, then tips descending as a cheap DB-level hint.
         // The frontend applies the full scored ranking after receiving the payload.
         .orderBy(
@@ -326,7 +339,7 @@ export class SearchService {
     }
 
     if (!type || type === "track") {
-      const tracks = await this.trackRepo
+      const trackSuggQb = this.trackRepo
         .createQueryBuilder("track")
         .leftJoinAndSelect("track.artist", "artist")
         .select([
@@ -339,8 +352,12 @@ export class SearchService {
           "artist.id",
           "artist.artistName",
         ])
-        .where(`(track.title ILIKE :like OR track.genre ILIKE :like)`, { like })
-        .andWhere("track.isPublic = :isPublic", { isPublic: true })
+        .where(`(track.title ILIKE :like OR track.genre ILIKE :like)`, { like });
+
+      // Apply visibility policy — replaces the inline isPublic check with the full policy
+      SearchVisibilityPolicy.applyTrackVisibility(trackSuggQb, "track", "artist");
+
+      const tracks = await trackSuggQb
         // Same DB-level hint for tracks
         .orderBy(
           `CASE WHEN track.title ILIKE :prefix THEN 0 ELSE 1 END`,

--- a/backend/src/storage/storage-provider.interface.ts
+++ b/backend/src/storage/storage-provider.interface.ts
@@ -1,0 +1,57 @@
+/**
+ * Abstract storage provider interface.
+ *
+ * All storage backends (local filesystem, S3, GCS, etc.) implement this
+ * contract so that higher-level modules (TracksService, etc.) never depend
+ * on local-filesystem specifics.
+ */
+export interface StorageFileResult {
+  /** Storage-unique identifier (filename, object key, etc.). */
+  filename: string;
+  /** Absolute path or remote URI (implementation-defined). */
+  path: string;
+  /** Public or pre-signed URL for client-side access. */
+  url: string;
+}
+
+export interface StorageFileInfo {
+  exists: boolean;
+  size?: number;
+  mimeType?: string;
+}
+
+export interface IStorageProvider {
+  /**
+   * Validate the file before persistence.
+   * Throws BadRequestException on any constraint violation.
+   */
+  validateFile(file: Express.Multer.File): Promise<void>;
+
+  /**
+   * Persist the file and return stable references.
+   * Implementations must be atomic: either the file is fully written or
+   * nothing is written and an error is thrown.
+   */
+  saveFile(file: Express.Multer.File): Promise<StorageFileResult>;
+
+  /**
+   * Remove the file identified by `filename`.
+   * Implementations should be idempotent: a missing file should not throw.
+   */
+  deleteFile(filename: string): Promise<void>;
+
+  /** Return metadata for an existing file. */
+  getFileInfo(filename: string): Promise<StorageFileInfo>;
+
+  /** Return a URL suitable for streaming/downloading. */
+  getStreamingUrl(filename: string): Promise<string>;
+
+  /** Derive a unique storage key from an original filename. */
+  generateUniqueFileName(originalName: string): string;
+
+  /** Resolve the full path or URI for direct backend access. */
+  getFilePath(filename: string): string;
+}
+
+/** Injection token for the active storage provider. */
+export const STORAGE_PROVIDER = Symbol('STORAGE_PROVIDER');

--- a/backend/src/storage/storage.module.ts
+++ b/backend/src/storage/storage.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { MulterModule } from '@nestjs/platform-express';
 import { StorageService } from './storage.service';
 import { StorageController } from './storage.controller';
+import { STORAGE_PROVIDER } from './storage-provider.interface';
 
 @Module({
   imports: [
@@ -14,7 +15,12 @@ import { StorageController } from './storage.controller';
     }),
   ],
   controllers: [StorageController],
-  providers: [StorageService],
-  exports: [StorageService],
+  providers: [
+    StorageService,
+    // Bind the abstract token to the local-filesystem implementation.
+    // To swap in a remote backend (S3, GCS, etc.) replace this binding.
+    { provide: STORAGE_PROVIDER, useExisting: StorageService },
+  ],
+  exports: [StorageService, STORAGE_PROVIDER],
 })
 export class StorageModule {}

--- a/backend/src/storage/storage.service.ts
+++ b/backend/src/storage/storage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { IStorageProvider, StorageFileResult, StorageFileInfo } from './storage-provider.interface';
 import { ConfigService } from '@nestjs/config';
 import { v4 as uuidv4 } from 'uuid';
 import * as path from 'path';
@@ -48,7 +49,7 @@ const MIME_TO_EXTENSIONS: Record<string, string[]> = {
 };
 
 @Injectable()
-export class StorageService {
+export class StorageService implements IStorageProvider {
   private readonly logger = new Logger(StorageService.name);
   private readonly allowedMimeTypes = [
     'audio/mpeg',

--- a/backend/src/tracks/track-file-reaper.service.ts
+++ b/backend/src/tracks/track-file-reaper.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Track } from './entities/track.entity';
+import { StorageService } from '../storage/storage.service';
+
+/**
+ * Track File Reaper — compensating cleanup for two-phase persistence failures.
+ *
+ * Phase ordering for CREATE:
+ *   1. Save file to storage (reversible — reaper can delete orphans)
+ *   2. Save Track row to DB  (if this fails, reaper cleans up the orphaned file)
+ *
+ * Phase ordering for DELETE:
+ *   1. Soft-delete DB row (record preserved with deletedAt + orphanedFilename)
+ *   2. Delete file from storage (if this fails, reaper retries later)
+ *
+ * The reaper runs periodically and:
+ *   - Deletes files whose uploads have no corresponding DB row
+ *     (orphaned by a failed CREATE after file save).
+ *   - Deletes files referenced by soft-deleted DB rows
+ *     (orphaned by a failed storage delete).
+ */
+@Injectable()
+export class TrackFileReaperService {
+  private readonly logger = new Logger(TrackFileReaperService.name);
+
+  /** Minimum age (ms) before an orphan is eligible for cleanup. Avoids racing live uploads. */
+  private readonly orphanMinAgeMs = 5 * 60 * 1000; // 5 minutes
+
+  constructor(
+    @InjectRepository(Track)
+    private readonly trackRepo: Repository<Track>,
+    private readonly storageService: StorageService,
+  ) {}
+
+  /**
+   * Attempt to delete an orphaned file that was written before a DB save failed.
+   * Called inline from TracksService.create on error.
+   */
+  async cleanupOrphanedFile(filename: string): Promise<void> {
+    try {
+      await this.storageService.deleteFile(filename);
+      this.logger.log(`[reaper] cleaned up orphaned file after failed DB save: ${filename}`);
+    } catch (err) {
+      this.logger.warn(
+        `[reaper] could not immediately clean orphaned file "${filename}", will retry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Retry deleting files referenced by soft-deleted Track rows.
+   * Called by a scheduler on a configurable interval.
+   *
+   * @returns number of files successfully reaped in this run.
+   */
+  async reapSoftDeletedFiles(): Promise<number> {
+    const cutoff = new Date(Date.now() - this.orphanMinAgeMs);
+
+    // Find soft-deleted rows that still have an undeleted file reference
+    const orphaned = await this.trackRepo
+      .createQueryBuilder('track')
+      .withDeleted()
+      .where('track.deletedAt IS NOT NULL')
+      .andWhere('track.deletedAt < :cutoff', { cutoff })
+      .andWhere('track.filename IS NOT NULL')
+      .andWhere("track.filename != ''")
+      .getMany();
+
+    if (orphaned.length === 0) {
+      return 0;
+    }
+
+    this.logger.log(`[reaper] found ${orphaned.length} soft-deleted track(s) with pending file cleanup`);
+
+    let reaped = 0;
+    for (const track of orphaned) {
+      try {
+        const info = await this.storageService.getFileInfo(track.filename!);
+        if (info.exists) {
+          await this.storageService.deleteFile(track.filename!);
+          this.logger.log(`[reaper] deleted orphaned file for track ${track.id}: ${track.filename}`);
+        }
+
+        // Clear the filename so this row is not retried
+        await this.trackRepo
+          .createQueryBuilder()
+          .update(Track)
+          .set({ filename: null as unknown as string })
+          .where('id = :id', { id: track.id })
+          .withDeleted()
+          .execute();
+
+        reaped++;
+      } catch (err) {
+        this.logger.warn(
+          `[reaper] failed to reap file for track ${track.id} ("${track.filename}"): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    this.logger.log(`[reaper] reaped ${reaped}/${orphaned.length} file(s)`);
+    return reaped;
+  }
+}

--- a/backend/src/tracks/tracks.service.ts
+++ b/backend/src/tracks/tracks.service.ts
@@ -20,6 +20,7 @@ import { LicensingService } from "@/track-listening-right-management/licensing.s
 import { PaginatedResult } from "@/events-live-show/events.service";
 import { ResourceNotFoundException } from "../common/exceptions/api-exception";
 import { PlayCountService } from "../track-play-count/play-count.service";
+import { TrackFileReaperService } from "./track-file-reaper.service";
 
 @Injectable()
 export class TracksService {
@@ -34,6 +35,7 @@ export class TracksService {
     private eventEmitter: EventEmitter2,
     private licensingService: LicensingService,
     private playCountService: PlayCountService,
+    private readonly reaperService: TrackFileReaperService,
   ) {}
 
   async create(
@@ -49,7 +51,8 @@ export class TracksService {
       let mimeType: string;
 
       if (file) {
-        // Save file first
+        // Phase 1: persist the file to storage.
+        // If Phase 2 (DB save) fails below, the reaper will delete this file.
         const fileResult = await this.storageService.saveFile(file);
         const fileInfo = await this.storageService.getFileInfo(
           fileResult.filename,
@@ -65,7 +68,8 @@ export class TracksService {
         audioUrl = url;
       }
 
-      // Create track record
+      // Phase 2: persist the DB record.
+      // If this fails and a file was written in Phase 1, compensate immediately.
       const track = this.tracksRepository.create({
         ...createTrackDto,
         audioUrl,
@@ -76,7 +80,16 @@ export class TracksService {
         mimeType,
       });
 
-      const savedTrack = await this.tracksRepository.save(track);
+      let savedTrack: Track;
+      try {
+        savedTrack = await this.tracksRepository.save(track);
+      } catch (dbError) {
+        // Compensating action: remove the orphaned file we wrote in Phase 1.
+        if (filename) {
+          await this.reaperService.cleanupOrphanedFile(filename);
+        }
+        throw dbError;
+      }
       this.logger.log(`Track created successfully: ${savedTrack.id}`);
 
       try {
@@ -208,13 +221,31 @@ export class TracksService {
     const track = await this.findOne(id);
 
     try {
-      // Delete file from storage if it exists
-      if (track.filename) {
-        await this.storageService.deleteFile(track.filename);
-      }
+      // Phase 1: soft-delete the DB row first so the record is preserved
+      // even if storage deletion fails.  The reaper will retry the file
+      // deletion asynchronously using track.filename.
+      await this.tracksRepository.softDelete(id);
+      this.logger.log(`Track soft-deleted: ${id}`);
 
-      // Delete track record
-      await this.tracksRepository.remove(track);
+      // Phase 2: attempt immediate file deletion.
+      // If it fails, the reaper will clean it up from the soft-deleted row.
+      if (track.filename) {
+        try {
+          await this.storageService.deleteFile(track.filename);
+          // Clear filename so the reaper skips it on the next run
+          await this.tracksRepository
+            .createQueryBuilder()
+            .update(Track)
+            .set({ filename: null as unknown as string })
+            .where('id = :id', { id })
+            .withDeleted()
+            .execute();
+        } catch (storageErr) {
+          this.logger.warn(
+            `Storage delete failed for track ${id} — reaper will retry: ${storageErr instanceof Error ? storageErr.message : String(storageErr)}`,
+          );
+        }
+      }
 
       this.logger.log(`Track deleted successfully: ${id}`);
     } catch (error) {


### PR DESCRIPTION
Fixes #504
Fixes #505
Fixes #506
Fixes #507

## What changed

### #504 — Payout Request Idempotency Keys

**`payout-request.entity.ts`** — Added `idempotencyKey varchar(128) nullable unique` column with `@Index()`.

**`create-payout.dto.ts`** — Added optional `idempotencyKey?: string` field with `@IsOptional @IsString @Length(1,128)`.

**`payouts.service.ts`** — `requestPayout` checks for an existing row matching the key before any balance/duplicate validation; if found, logs and replays the original result immediately. Stores the key on new payout rows. Retries with the same key are safe — they never create a duplicate pending row.

**`migrations/1771000001000-AddPayoutIdempotencyKey.ts`** — Adds the column and a partial unique index (`WHERE idempotencyKey IS NOT NULL`) so null rows don't interfere with the uniqueness constraint.

### #505 — Track File Orphan Cleanup and Two-Phase Persistence

**`track-file-reaper.service.ts`** (new) — `cleanupOrphanedFile(filename)` for inline compensating cleanup; `reapSoftDeletedFiles()` for scheduler-driven cleanup of soft-deleted rows whose file wasn't successfully deleted.

**`tracks.service.ts`** — `create`: Phase 1 saves file, Phase 2 saves DB row; on DB failure the reaper's `cleanupOrphanedFile` runs immediately. `remove`: Phase 1 soft-deletes the DB row (preserves reference), Phase 2 attempts immediate storage deletion; on storage failure the row retains `filename` for the reaper to retry.

### #506 — Storage Backend Abstraction

**`storage-provider.interface.ts`** (new) — `IStorageProvider` interface with `validateFile`, `saveFile`, `deleteFile`, `getFileInfo`, `getStreamingUrl`, `generateUniqueFileName`, `getFilePath`. Also exports `STORAGE_PROVIDER` injection token.

**`storage.service.ts`** — `StorageService implements IStorageProvider` (no API changes; purely additive).

**`storage.module.ts`** — Registers `{ provide: STORAGE_PROVIDER, useExisting: StorageService }` so consumers can inject `IStorageProvider` via the token. Swapping to a remote backend requires only changing this binding.

### #507 — Search Visibility and Soft-Delete Enforcement

**`search-visibility.policy.ts`** (new) — `SearchVisibilityPolicy` static class with:
- `applyArtistVisibility(qb, alias)` — `deletedAt IS NULL`, `isDeleted = false`, `isPublic = true`
- `applyTrackVisibility(qb, trackAlias, artistAlias?)` — `deletedAt IS NULL`, `isPublic = true`, plus artist deletion checks when alias provided
- `applyArtistStatusConstraint(qb, alias, excludedStatuses)` — optional status exclusion

**`search.service.ts`** — Policy applied to all four query builders: `searchArtists`, `searchTracks`, and both suggestion queries. The inline `isPublic` check on track suggestions is replaced by the full policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotency support for payout requests—repeated requests with the same key return the previous outcome instead of creating duplicates.
  * Implemented search visibility policies to ensure deleted and private content is excluded from search results.
  * Added automatic cleanup for orphaned track files resulting from failed uploads.

* **Chores**
  * Abstracted storage provider as a dependency injection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->