### PR TITLE
feat: claim locking, licensing lifecycle, delivery outbox, payout audit integrity

### DIFF
--- a/backend/src/artiste-payout/payout-audit.writer.ts
+++ b/backend/src/artiste-payout/payout-audit.writer.ts
@@ -1,0 +1,169 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository, QueryRunner } from "typeorm";
+import {
+  ArtistBalanceAudit,
+  ArtistBalanceAuditType,
+} from "./artist-balance-audit.entity";
+
+export interface AuditWriteParams {
+  artistId: string;
+  assetCode: "XLM" | "USDC";
+  eventType: ArtistBalanceAuditType;
+  amount: number;
+  balanceBefore: number;
+  balanceAfter: number;
+  pendingBefore: number;
+  pendingAfter: number;
+  payoutRequestId?: string;
+  tipId?: string;
+}
+
+/**
+ * Transaction-aware audit writer for payout balance mutations.
+ *
+ * Pass the active `QueryRunner` so the audit row participates in the same
+ * DB transaction as the balance mutation. If the transaction rolls back,
+ * the audit row rolls back with it — no audit drift.
+ *
+ * Omit `qr` only for stand-alone writes that are not paired with a
+ * balance change (auto-commit mode).
+ */
+@Injectable()
+export class PayoutAuditWriter {
+  constructor(
+    @InjectRepository(ArtistBalanceAudit)
+    private readonly auditRepo: Repository<ArtistBalanceAudit>,
+  ) {}
+
+  private repo(qr?: QueryRunner): Repository<ArtistBalanceAudit> {
+    return qr
+      ? qr.manager.getRepository(ArtistBalanceAudit)
+      : this.auditRepo;
+  }
+
+  async write(params: AuditWriteParams, qr?: QueryRunner): Promise<ArtistBalanceAudit> {
+    const repo = this.repo(qr);
+    const audit = repo.create({
+      artistId: params.artistId,
+      assetCode: params.assetCode,
+      eventType: params.eventType,
+      amount: params.amount,
+      balanceBefore: params.balanceBefore,
+      balanceAfter: params.balanceAfter,
+      pendingBefore: params.pendingBefore,
+      pendingAfter: params.pendingAfter,
+      payoutRequestId: params.payoutRequestId,
+      tipId: params.tipId,
+    });
+    return repo.save(audit);
+  }
+
+  async writeTipCredit(
+    artistId: string,
+    assetCode: "XLM" | "USDC",
+    amount: number,
+    balanceBefore: number,
+    balanceAfter: number,
+    pendingBefore: number,
+    pendingAfter: number,
+    tipId: string,
+    qr?: QueryRunner,
+  ): Promise<ArtistBalanceAudit> {
+    return this.write(
+      {
+        artistId,
+        assetCode,
+        eventType: ArtistBalanceAuditType.TIP_CREDIT,
+        amount,
+        balanceBefore,
+        balanceAfter,
+        pendingBefore,
+        pendingAfter,
+        tipId,
+      },
+      qr,
+    );
+  }
+
+  async writePayoutRequest(
+    artistId: string,
+    assetCode: "XLM" | "USDC",
+    amount: number,
+    balanceBefore: number,
+    balanceAfter: number,
+    pendingBefore: number,
+    pendingAfter: number,
+    payoutRequestId: string,
+    qr?: QueryRunner,
+  ): Promise<ArtistBalanceAudit> {
+    return this.write(
+      {
+        artistId,
+        assetCode,
+        eventType: ArtistBalanceAuditType.PAYOUT_REQUEST,
+        amount,
+        balanceBefore,
+        balanceAfter,
+        pendingBefore,
+        pendingAfter,
+        payoutRequestId,
+      },
+      qr,
+    );
+  }
+
+  async writePayoutCompleted(
+    artistId: string,
+    assetCode: "XLM" | "USDC",
+    amount: number,
+    balanceBefore: number,
+    balanceAfter: number,
+    pendingBefore: number,
+    pendingAfter: number,
+    payoutRequestId: string,
+    qr?: QueryRunner,
+  ): Promise<ArtistBalanceAudit> {
+    return this.write(
+      {
+        artistId,
+        assetCode,
+        eventType: ArtistBalanceAuditType.PAYOUT_COMPLETED,
+        amount,
+        balanceBefore,
+        balanceAfter,
+        pendingBefore,
+        pendingAfter,
+        payoutRequestId,
+      },
+      qr,
+    );
+  }
+
+  async writePayoutFailed(
+    artistId: string,
+    assetCode: "XLM" | "USDC",
+    amount: number,
+    balanceBefore: number,
+    balanceAfter: number,
+    pendingBefore: number,
+    pendingAfter: number,
+    payoutRequestId: string,
+    qr?: QueryRunner,
+  ): Promise<ArtistBalanceAudit> {
+    return this.write(
+      {
+        artistId,
+        assetCode,
+        eventType: ArtistBalanceAuditType.PAYOUT_FAILED,
+        amount,
+        balanceBefore,
+        balanceAfter,
+        pendingBefore,
+        pendingAfter,
+        payoutRequestId,
+      },
+      qr,
+    );
+  }
+}

--- a/backend/src/artiste-payout/payouts.service.ts
+++ b/backend/src/artiste-payout/payouts.service.ts
@@ -11,6 +11,7 @@ import { Repository, DataSource, QueryRunner } from "typeorm";
 import { ConfigService } from "@nestjs/config";
 import { ArtistBalance } from "./artist-balance.entity";
 import { ArtistBalanceAudit, ArtistBalanceAuditType } from "./artist-balance-audit.entity";
+import { PayoutAuditWriter } from "./payout-audit.writer";
 import { PayoutRequest, PayoutStatus } from "./payout-request.entity";
 import { CreatePayoutDto } from "./create-payout.dto";
 import { Artist } from "../artists/entities/artist.entity";
@@ -32,6 +33,7 @@ export class PayoutsService {
     private readonly artistRepo: Repository<Artist>,
     private readonly dataSource: DataSource,
     private readonly config: ConfigService,
+    private readonly auditWriter: PayoutAuditWriter,
   ) {
     this.minXlmThreshold = this.config.get<number>("PAYOUT_MIN_XLM", 10);
     this.minUsdcThreshold = this.config.get<number>("PAYOUT_MIN_USDC", 5);
@@ -209,30 +211,16 @@ export class PayoutsService {
         .findOne({ where: { artistId } });
 
       if (afterBalance) {
-        await this.auditRepo.save(
-          this.auditRepo.create({
-            artistId,
-            assetCode,
-            eventType: ArtistBalanceAuditType.PAYOUT_REQUEST,
-            amount: amount * -1,
-            payoutRequestId: saved.id,
-            balanceBefore:
-              assetCode === "XLM"
-                ? Number(balance.xlmBalance)
-                : Number(balance.usdcBalance),
-            balanceAfter:
-              assetCode === "XLM"
-                ? Number(afterBalance.xlmBalance)
-                : Number(afterBalance.usdcBalance),
-            pendingBefore:
-              assetCode === "XLM"
-                ? Number(balance.pendingXlm)
-                : Number(balance.pendingUsdc),
-            pendingAfter:
-              assetCode === "XLM"
-                ? Number(afterBalance.pendingXlm)
-                : Number(afterBalance.pendingUsdc),
-          }),
+        await this.auditWriter.writePayoutRequest(
+          artistId,
+          assetCode,
+          amount * -1,
+          assetCode === "XLM" ? Number(balance.xlmBalance) : Number(balance.usdcBalance),
+          assetCode === "XLM" ? Number(afterBalance.xlmBalance) : Number(afterBalance.usdcBalance),
+          assetCode === "XLM" ? Number(balance.pendingXlm) : Number(balance.pendingUsdc),
+          assetCode === "XLM" ? Number(afterBalance.pendingXlm) : Number(afterBalance.pendingUsdc),
+          saved.id,
+          qr,
         );
       }
 

--- a/backend/src/scheduled-releases/entities/scheduled-release.entity.ts
+++ b/backend/src/scheduled-releases/entities/scheduled-release.entity.ts
@@ -68,6 +68,14 @@ export class ScheduledRelease {
   @Column({ type: "timestamp", nullable: true })
   failedAt: Date;
 
+  /** Worker instance ID that currently holds the publish lease, or null. */
+  @Column({ type: "text", nullable: true })
+  claimedBy: string | null;
+
+  /** When the current lease expires; workers must renew or release before this time. */
+  @Column({ type: "timestamp", nullable: true })
+  claimExpiresAt: Date | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/scheduled-releases/scheduled-release-lock.service.ts
+++ b/backend/src/scheduled-releases/scheduled-release-lock.service.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { DataSource, Repository, LessThan } from "typeorm";
+import {
+  ScheduledRelease,
+  ReleaseStatus,
+} from "./entities/scheduled-release.entity";
+
+/** How long (ms) a claim lease is held before another worker may steal it. */
+const LEASE_TTL_MS = 60_000; // 1 minute
+
+/**
+ * Provides exactly-once claim semantics for scheduled-release publication.
+ *
+ * Uses a single `UPDATE … WHERE claimedBy IS NULL (OR claimExpiresAt < NOW)`
+ * conditional update so only one worker wins the race — no advisory locks or
+ * external services required.
+ */
+@Injectable()
+export class ScheduledReleaseLockService {
+  private readonly logger = new Logger(ScheduledReleaseLockService.name);
+
+  constructor(
+    @InjectRepository(ScheduledRelease)
+    private readonly repo: Repository<ScheduledRelease>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /**
+   * Attempt to claim `releaseId` for `workerId`.
+   *
+   * Returns `true` when this worker won the lease, `false` when another
+   * worker already holds a valid lease.
+   *
+   * The claim is granted only when:
+   * - `claimedBy` is NULL (never claimed), OR
+   * - `claimExpiresAt` is in the past (previous lease expired).
+   *
+   * The status is atomically moved to PUBLISHING on success.
+   */
+  async claimRelease(releaseId: string, workerId: string): Promise<boolean> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + LEASE_TTL_MS);
+
+    const result = await this.dataSource
+      .createQueryBuilder()
+      .update(ScheduledRelease)
+      .set({
+        claimedBy: workerId,
+        claimExpiresAt: expiresAt,
+        status: ReleaseStatus.PUBLISHING,
+        lastAttemptAt: now,
+      })
+      .where("id = :id", { id: releaseId })
+      .andWhere("status = :status", { status: ReleaseStatus.PENDING })
+      .andWhere(
+        "(claimedBy IS NULL OR claimExpiresAt < :now)",
+        { now },
+      )
+      .execute();
+
+    const claimed = (result.affected ?? 0) > 0;
+    if (claimed) {
+      this.logger.debug(`Worker ${workerId} claimed release ${releaseId}`);
+    }
+    return claimed;
+  }
+
+  /**
+   * Release the claim after successful or permanently-failed publication.
+   * Clears the lease fields and sets the terminal status.
+   */
+  async releaseClaim(
+    releaseId: string,
+    workerId: string,
+    terminalStatus: ReleaseStatus.PUBLISHED | ReleaseStatus.FAILED_PERMANENTLY,
+    extra: Partial<ScheduledRelease> = {},
+  ): Promise<void> {
+    await this.repo.update(
+      { id: releaseId, claimedBy: workerId },
+      {
+        claimedBy: null,
+        claimExpiresAt: null,
+        status: terminalStatus,
+        ...extra,
+      },
+    );
+  }
+
+  /**
+   * Reset stale leases so they become claimable again.
+   *
+   * Call periodically (e.g. every 30 s) to recover from workers that died
+   * mid-publication without releasing their lease.
+   */
+  async releaseExpiredLeases(): Promise<number> {
+    const result = await this.dataSource
+      .createQueryBuilder()
+      .update(ScheduledRelease)
+      .set({
+        claimedBy: null,
+        claimExpiresAt: null,
+        status: ReleaseStatus.PENDING,
+      })
+      .where("status = :status", { status: ReleaseStatus.PUBLISHING })
+      .andWhere("claimExpiresAt < :now", { now: new Date() })
+      .execute();
+
+    const count = result.affected ?? 0;
+    if (count > 0) {
+      this.logger.warn(`Reset ${count} expired release lease(s)`);
+    }
+    return count;
+  }
+}

--- a/backend/src/track-listening-right-management/license-request.entity.ts
+++ b/backend/src/track-listening-right-management/license-request.entity.ts
@@ -4,8 +4,11 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
+import { LicensingLifecycle } from './licensing-lifecycle.enum';
 
+/** @deprecated Use LicensingLifecycle for new code. Kept for backward compatibility. */
 export enum LicenseRequestStatus {
   PENDING = 'pending',
   APPROVED = 'approved',
@@ -13,6 +16,8 @@ export enum LicenseRequestStatus {
 }
 
 @Entity('license_requests')
+@Index(['requesterId', 'status'])
+@Index(['trackId', 'status'])
 export class LicenseRequest {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -28,16 +33,28 @@ export class LicenseRequest {
 
   @Column({
     type: 'enum',
-    enum: LicenseRequestStatus,
-    default: LicenseRequestStatus.PENDING,
+    enum: LicensingLifecycle,
+    default: LicensingLifecycle.PENDING,
   })
-  status: LicenseRequestStatus;
+  status: LicensingLifecycle;
 
   @Column({ type: 'text', nullable: true })
-  responseMessage: string;
+  responseMessage: string | null;
 
   @Column({ nullable: true })
-  respondedAt: Date;
+  respondedAt: Date | null;
+
+  /** When this request automatically transitions to EXPIRED if unanswered. */
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date | null;
+
+  /** When the request was withdrawn by the requester. */
+  @Column({ type: 'timestamp', nullable: true })
+  withdrawnAt: Date | null;
+
+  /** When the request was reopened after expiry. */
+  @Column({ type: 'timestamp', nullable: true })
+  reopenedAt: Date | null;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/track-listening-right-management/licensing-delivery.queue.ts
+++ b/backend/src/track-listening-right-management/licensing-delivery.queue.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+export type DeliveryType = "mail" | "notification";
+
+export interface DeliveryJob {
+  id: string;
+  type: DeliveryType;
+  referenceId: string;
+  payload: Record<string, unknown>;
+  attempts: number;
+  maxAttempts: number;
+  lastError: string | null;
+  scheduledAt: Date;
+  exhausted: boolean;
+}
+
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 5_000;
+
+/**
+ * In-process outbox for licensing mail and notification delivery.
+ *
+ * Keeps request creation synchronous while deferring external delivery
+ * to a background retry loop. Failed deliveries are captured with retry
+ * metadata instead of being silently dropped.
+ *
+ * Replace the `execute` method with a real queue (BullMQ, etc.) when
+ * moving to a distributed deployment.
+ */
+@Injectable()
+export class LicensingDeliveryQueue {
+  private readonly logger = new Logger(LicensingDeliveryQueue.name);
+  private readonly jobs = new Map<string, DeliveryJob>();
+  private ticker: NodeJS.Timeout | null = null;
+
+  onModuleInit() {
+    this.ticker = setInterval(() => this.flush(), RETRY_DELAY_MS);
+  }
+
+  onModuleDestroy() {
+    if (this.ticker) clearInterval(this.ticker);
+  }
+
+  enqueue(
+    type: DeliveryType,
+    referenceId: string,
+    payload: Record<string, unknown>,
+  ): string {
+    const id = `${type}:${referenceId}:${Date.now()}`;
+    const job: DeliveryJob = {
+      id,
+      type,
+      referenceId,
+      payload,
+      attempts: 0,
+      maxAttempts: MAX_ATTEMPTS,
+      lastError: null,
+      scheduledAt: new Date(),
+      exhausted: false,
+    };
+    this.jobs.set(id, job);
+    this.logger.debug(`Enqueued ${type} delivery for ${referenceId} [${id}]`);
+    return id;
+  }
+
+  /** Retrieve a job by ID (useful in tests / observability). */
+  getJob(id: string): DeliveryJob | undefined {
+    return this.jobs.get(id);
+  }
+
+  /** All jobs, including exhausted ones. */
+  allJobs(): DeliveryJob[] {
+    return Array.from(this.jobs.values());
+  }
+
+  pendingJobs(): DeliveryJob[] {
+    return this.allJobs().filter((j) => !j.exhausted && j.attempts < j.maxAttempts);
+  }
+
+  exhaustedJobs(): DeliveryJob[] {
+    return this.allJobs().filter((j) => j.exhausted);
+  }
+
+  /**
+   * Register a delivery executor. The executor receives each pending job
+   * and should throw on failure so the queue can record the error and retry.
+   */
+  registerExecutor(
+    executor: (job: DeliveryJob) => Promise<void>,
+  ): void {
+    this.executor = executor;
+  }
+
+  private executor: ((job: DeliveryJob) => Promise<void>) | null = null;
+
+  async flush(): Promise<void> {
+    if (!this.executor) return;
+    for (const job of this.pendingJobs()) {
+      try {
+        job.attempts += 1;
+        await this.executor(job);
+        this.jobs.delete(job.id);
+        this.logger.debug(`Delivered ${job.type} job ${job.id} (attempt ${job.attempts})`);
+      } catch (err) {
+        job.lastError = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          `Delivery failed for job ${job.id} (attempt ${job.attempts}/${job.maxAttempts}): ${job.lastError}`,
+        );
+        if (job.attempts >= job.maxAttempts) {
+          job.exhausted = true;
+          this.logger.error(
+            `Job ${job.id} exhausted after ${job.maxAttempts} attempts — manual replay required`,
+          );
+        }
+      }
+    }
+  }
+}

--- a/backend/src/track-listening-right-management/licensing-lifecycle.enum.ts
+++ b/backend/src/track-listening-right-management/licensing-lifecycle.enum.ts
@@ -1,0 +1,42 @@
+/**
+ * Full lifecycle of a license request.
+ *
+ * Valid transitions:
+ *
+ *   PENDING → APPROVED      (artist responds positively)
+ *   PENDING → REJECTED      (artist responds negatively)
+ *   PENDING → WITHDRAWN     (requester cancels before response)
+ *   PENDING → EXPIRED       (TTL passed without any response)
+ *   EXPIRED → REOPENED      (requester restarts the request)
+ *   REOPENED → APPROVED     (artist approves the reopened request)
+ *   REOPENED → REJECTED     (artist rejects the reopened request)
+ *   REOPENED → WITHDRAWN    (requester withdraws the reopened request)
+ *
+ * Terminal states: APPROVED, REJECTED, WITHDRAWN
+ * (EXPIRED can be reopened once; REOPENED follows the same rules as PENDING)
+ */
+export enum LicensingLifecycle {
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+  WITHDRAWN = "withdrawn",
+  EXPIRED = "expired",
+  REOPENED = "reopened",
+}
+
+/** States from which a requester may withdraw. */
+export const WITHDRAWABLE_STATES: LicensingLifecycle[] = [
+  LicensingLifecycle.PENDING,
+  LicensingLifecycle.REOPENED,
+];
+
+/** States from which a request may be reopened. */
+export const REOPENABLE_STATES: LicensingLifecycle[] = [
+  LicensingLifecycle.EXPIRED,
+];
+
+/** States that the artist can respond to (approve/reject). */
+export const RESPONDABLE_STATES: LicensingLifecycle[] = [
+  LicensingLifecycle.PENDING,
+  LicensingLifecycle.REOPENED,
+];

--- a/backend/src/track-listening-right-management/licensing.service.ts
+++ b/backend/src/track-listening-right-management/licensing.service.ts
@@ -7,13 +7,23 @@ import {
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { TrackLicense, LicenseType } from "./track-license.entity";
-import { LicenseRequest, LicenseRequestStatus } from "./license-request.entity";
+import { LicenseRequest } from "./license-request.entity";
+import {
+  LicensingLifecycle,
+  WITHDRAWABLE_STATES,
+  REOPENABLE_STATES,
+  RESPONDABLE_STATES,
+} from "./licensing-lifecycle.enum";
+
+/** @deprecated kept for callers that still reference the old enum */
+export { LicenseRequestStatus } from "./license-request.entity";
 import {
   CreateTrackLicenseDto,
   CreateLicenseRequestDto,
   RespondToLicenseRequestDto,
 } from "./licensing.dto";
 import { LicensingMailService } from "./licensing-mail.service";
+import { LicensingDeliveryQueue } from "./licensing-delivery.queue";
 import { NotificationsService } from "@/notifications/notifications.service";
 import { Track } from "@/tracks/entities/track.entity";
 import { NotificationType } from "@/notifications/notification.entity";
@@ -29,6 +39,7 @@ export class LicensingService {
     private readonly licenseRequestRepo: Repository<LicenseRequest>,
     private readonly mailService: LicensingMailService,
     private readonly notificationsService: NotificationsService,
+    private readonly deliveryQueue: LicensingDeliveryQueue,
   ) {}
 
   // ── Track License ──────────────────────────────────────────────────────────
@@ -120,21 +131,19 @@ export class LicensingService {
     const saved = await this.licenseRequestRepo.save(request);
 
     if (track.artistId) {
-      this.notificationsService
-        .create({
-          userId: track.artistId,
-          type: NotificationType.LICENSE_REQUEST,
-          title: "New License Request",
-          message: `A user has requested a license for your track.`,
-          data: { requestId: saved.id, trackId: saved.trackId },
-        })
-        .catch((err) => console.error("Notification error:", err));
+      this.deliveryQueue.enqueue("notification", saved.id, {
+        userId: track.artistId,
+        type: NotificationType.LICENSE_REQUEST,
+        title: "New License Request",
+        message: `A user has requested a license for your track.`,
+        data: { requestId: saved.id, trackId: saved.trackId },
+      });
     }
 
-    // Notify artist (fire-and-forget)
-    this.mailService
-      .notifyArtistOfNewRequest(saved)
-      .catch((err) => console.error("Mail error:", err));
+    this.deliveryQueue.enqueue("mail", saved.id, {
+      kind: "newRequest",
+      requestId: saved.id,
+    });
 
     return saved;
   }
@@ -169,31 +178,94 @@ export class LicensingService {
       );
     }
 
-    if (request.status !== LicenseRequestStatus.PENDING) {
-      throw new BadRequestException("Request has already been responded to.");
+    if (!RESPONDABLE_STATES.includes(request.status as LicensingLifecycle)) {
+      throw new BadRequestException("Request is not in a state that can be responded to.");
     }
 
-    request.status = dto.status;
+    request.status = dto.status as unknown as LicensingLifecycle;
     request.responseMessage = dto.responseMessage ?? null;
     request.respondedAt = new Date();
 
     const saved = await this.licenseRequestRepo.save(request);
 
-    this.notificationsService
-      .create({
-        userId: request.requesterId,
-        type: NotificationType.LICENSE_RESPONSE,
-        title: `License Request ${dto.status.toUpperCase()}`,
-        message: `Your request for track ${request.trackId} has been ${dto.status}.`,
-        data: { requestId: saved.id, status: dto.status },
-      })
-      .catch((err) => console.error("Notification error:", err));
+    this.deliveryQueue.enqueue("notification", saved.id, {
+      userId: request.requesterId,
+      type: NotificationType.LICENSE_RESPONSE,
+      title: `License Request ${dto.status.toUpperCase()}`,
+      message: `Your request for track ${request.trackId} has been ${dto.status}.`,
+      data: { requestId: saved.id, status: dto.status },
+    });
 
-    // Notify requester
-    this.mailService
-      .notifyRequesterOfResponse(saved)
-      .catch((err) => console.error("Mail error:", err));
+    this.deliveryQueue.enqueue("mail", saved.id, {
+      kind: "response",
+      requestId: saved.id,
+    });
 
     return saved;
+  }
+
+  // ── Lifecycle extensions ────────────────────────────────────────────────────
+
+  async withdrawRequest(
+    requestId: string,
+    requesterId: string,
+  ): Promise<LicenseRequest> {
+    const request = await this.licenseRequestRepo.findOne({ where: { id: requestId } });
+    if (!request) throw new NotFoundException("License request not found.");
+    if (request.requesterId !== requesterId)
+      throw new ForbiddenException("You may only withdraw your own requests.");
+    if (!WITHDRAWABLE_STATES.includes(request.status as LicensingLifecycle))
+      throw new BadRequestException(
+        `Cannot withdraw a request in '${request.status}' state.`,
+      );
+
+    request.status = LicensingLifecycle.WITHDRAWN;
+    request.withdrawnAt = new Date();
+    return this.licenseRequestRepo.save(request);
+  }
+
+  async expireRequest(requestId: string): Promise<LicenseRequest> {
+    const request = await this.licenseRequestRepo.findOne({ where: { id: requestId } });
+    if (!request) throw new NotFoundException("License request not found.");
+    if (request.status !== LicensingLifecycle.PENDING)
+      throw new BadRequestException(
+        `Only PENDING requests can be expired; current status is '${request.status}'.`,
+      );
+
+    request.status = LicensingLifecycle.EXPIRED;
+    return this.licenseRequestRepo.save(request);
+  }
+
+  async reopenRequest(
+    requestId: string,
+    requesterId: string,
+  ): Promise<LicenseRequest> {
+    const request = await this.licenseRequestRepo.findOne({ where: { id: requestId } });
+    if (!request) throw new NotFoundException("License request not found.");
+    if (request.requesterId !== requesterId)
+      throw new ForbiddenException("You may only reopen your own requests.");
+    if (!REOPENABLE_STATES.includes(request.status as LicensingLifecycle))
+      throw new BadRequestException(
+        `Cannot reopen a request in '${request.status}' state.`,
+      );
+
+    request.status = LicensingLifecycle.REOPENED;
+    request.reopenedAt = new Date();
+    request.responseMessage = null;
+    request.respondedAt = null;
+    return this.licenseRequestRepo.save(request);
+  }
+
+  /** Expire all PENDING requests whose expiresAt has passed. */
+  async expireStalePendingRequests(): Promise<number> {
+    const result = await this.licenseRequestRepo
+      .createQueryBuilder()
+      .update(LicenseRequest)
+      .set({ status: LicensingLifecycle.EXPIRED })
+      .where("status = :status", { status: LicensingLifecycle.PENDING })
+      .andWhere("expiresAt IS NOT NULL")
+      .andWhere("expiresAt < :now", { now: new Date() })
+      .execute();
+    return result.affected ?? 0;
   }
 }


### PR DESCRIPTION
Closes #500
Closes #501
Closes #502
Closes #503

## What changed

### #500 — Scheduled Release Cross-Instance Claim Locking
- Added `claimedBy` and `claimExpiresAt` columns to `ScheduledRelease` entity
- New `ScheduledReleaseLockService` with `claimRelease(releaseId, workerId)` using a conditional `UPDATE … WHERE claimedBy IS NULL OR claimExpiresAt < NOW` so only one worker wins atomically
- `releaseClaim()` transitions to the terminal status; `releaseExpiredLeases()` recovers from crashed workers
- Publication is idempotent and exactly-once from the application's perspective

### #501 — Licensing Request Expiry, Withdrawal, and Reopen Flow
- New `licensing-lifecycle.enum.ts`: `LicensingLifecycle` with PENDING → APPROVED/REJECTED/WITHDRAWN/EXPIRED, EXPIRED → REOPENED, plus `WITHDRAWABLE_STATES`, `REOPENABLE_STATES`, `RESPONDABLE_STATES` sets
- Extended `LicenseRequest` entity: status uses the new enum, added `expiresAt`, `withdrawnAt`, `reopenedAt` columns
- Added `withdrawRequest()`, `expireRequest()`, `reopenRequest()`, `expireStalePendingRequests()` to `LicensingService` with correct transition guards

### #502 — Licensing Delivery Outbox and Structured Failure Handling
- New `LicensingDeliveryQueue`: in-process outbox with `enqueue()`, background `flush()`, retry up to 3 attempts, and exhausted-job tracking with structured error capture
- Replaced all fire-and-forget `console.error` delivery calls in `LicensingService` with `deliveryQueue.enqueue()` — failures are captured and retried, not silently dropped

### #503 — Payout Audit Transaction Integrity
- New `PayoutAuditWriter`: typed helpers (`writeTipCredit`, `writePayoutRequest`, `writePayoutCompleted`, `writePayoutFailed`) all accept an optional `QueryRunner` so audit rows participate in the caller's transaction
- Routed `requestPayout` audit write through `PayoutAuditWriter` with the active `QueryRunner` — audit rows now roll back atomically if the balance mutation fails

## How to test
- **#500** — Simulate two concurrent workers calling `claimRelease(id, workerA/B)`; only one returns `true`
- **#501** — Create a PENDING request → withdraw it → verify WITHDRAWN; create another → expire → reopen → verify REOPENED
- **#502** — Register an executor that throws on first call; verify `exhaustedJobs()` is populated after 3 attempts
- **#503** — In a test, start a transaction, call `requestPayout`, force a rollback, and confirm no audit row was written

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced licensing request workflow with new states enabling requesters to withdraw and reopen requests
  - Improved reliability and tracking of licensing notifications and email delivery
  - Better coordination for scheduled release publishing with distributed processing support

* **Refactor**
  - Streamlined payout audit logging infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->