### PR TITLE
Fix comment integrity and playlist change request revalidation

### DIFF
--- a/backend/migrations/1771000000000-AddDeletedAtToComments.ts
+++ b/backend/migrations/1771000000000-AddDeletedAtToComments.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDeletedAtToComments1771000000000 implements MigrationInterface {
+  name = "AddDeletedAtToComments1771000000000";
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "comments"
+      ADD COLUMN IF NOT EXISTS "deleted_at" timestamp NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_comments_track_parent_created_at"
+      ON "comments" ("track_id", "parent_comment_id", "created_at" DESC, "id" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_comments_track_parent_likes_created_at"
+      ON "comments" ("track_id", "parent_comment_id", "likes_count" DESC, "created_at" DESC, "id" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_comments_parent_created_at"
+      ON "comments" ("parent_comment_id", "created_at" ASC, "id" ASC)
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_comments_parent_created_at"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_comments_track_parent_likes_created_at"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_comments_track_parent_created_at"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "comments"
+      DROP COLUMN IF EXISTS "deleted_at"
+    `);
+  }
+}

--- a/backend/src/comments/comment-like-repair.service.spec.ts
+++ b/backend/src/comments/comment-like-repair.service.spec.ts
@@ -1,0 +1,95 @@
+import { NotFoundException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Comment } from "./comment.entity";
+import { CommentLike } from "./comment-like.entity";
+import { CommentLikeRepairService } from "./comment-like-repair.service";
+
+describe("CommentLikeRepairService", () => {
+  let service: CommentLikeRepairService;
+
+  const mockCommentRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockCommentLikeRepository = {
+    count: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentLikeRepairService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: mockCommentRepository,
+        },
+        {
+          provide: getRepositoryToken(CommentLike),
+          useValue: mockCommentLikeRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CommentLikeRepairService>(CommentLikeRepairService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("repairs a drifted likes count for a single comment", async () => {
+    const comment = {
+      id: "comment-uuid",
+      likesCount: 5,
+    } as Comment;
+
+    mockCommentRepository.findOne.mockResolvedValue(comment);
+    mockCommentLikeRepository.count.mockResolvedValue(2);
+    mockCommentRepository.save.mockResolvedValue({
+      ...comment,
+      likesCount: 2,
+    });
+
+    const result = await service.repairCommentLikesCount("comment-uuid");
+
+    expect(result.likesCount).toBe(2);
+    expect(mockCommentRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "comment-uuid",
+        likesCount: 2,
+      }),
+    );
+  });
+
+  it("throws when repairing a comment that does not exist", async () => {
+    mockCommentRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.repairCommentLikesCount("missing-comment"),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it("repairs all drifted comment counters", async () => {
+    mockCommentRepository.find.mockResolvedValue([
+      { id: "comment-1", likesCount: 4 },
+      { id: "comment-2", likesCount: 1 },
+    ]);
+    mockCommentLikeRepository.count
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(3);
+
+    const repairedCount = await service.repairAllCommentLikesCounts();
+
+    expect(repairedCount).toBe(1);
+    expect(mockCommentRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "comment-2",
+        likesCount: 3,
+      }),
+    );
+  });
+});

--- a/backend/src/comments/comment-like-repair.service.ts
+++ b/backend/src/comments/comment-like-repair.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Comment } from "./comment.entity";
+import { CommentLike } from "./comment-like.entity";
+
+@Injectable()
+export class CommentLikeRepairService {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+    @InjectRepository(CommentLike)
+    private readonly commentLikeRepository: Repository<CommentLike>,
+  ) {}
+
+  async repairCommentLikesCount(commentId: string): Promise<Comment> {
+    const comment = await this.commentRepository.findOne({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new NotFoundException("Comment not found");
+    }
+
+    const actualLikesCount = await this.commentLikeRepository.count({
+      where: { commentId },
+    });
+
+    if (comment.likesCount !== actualLikesCount) {
+      comment.likesCount = actualLikesCount;
+      await this.commentRepository.save(comment);
+    }
+
+    return comment;
+  }
+
+  async repairAllCommentLikesCounts(): Promise<number> {
+    const comments = await this.commentRepository.find();
+    let repairedCount = 0;
+
+    for (const comment of comments) {
+      const actualLikesCount = await this.commentLikeRepository.count({
+        where: { commentId: comment.id },
+      });
+
+      if (comment.likesCount !== actualLikesCount) {
+        comment.likesCount = actualLikesCount;
+        await this.commentRepository.save(comment);
+        repairedCount += 1;
+      }
+    }
+
+    return repairedCount;
+  }
+}

--- a/backend/src/comments/comment-like.entity.ts
+++ b/backend/src/comments/comment-like.entity.ts
@@ -6,35 +6,38 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   JoinColumn,
+  Index,
   Unique,
-} from 'typeorm';
-import { Comment } from './comment.entity';
-import { User } from '../users/entities/user.entity';
-import { AppBaseEntity } from '../common/entities/base.entity';
+} from "typeorm";
+import { Comment } from "./comment.entity";
+import { User } from "../users/entities/user.entity";
+import { AppBaseEntity } from "../common/entities/base.entity";
 
-@Entity('comment_likes')
-@Unique(['commentId', 'userId'])
+@Entity("comment_likes")
+@Unique("UQ_comment_likes_comment_user", ["commentId", "userId"])
+@Index(["commentId"])
+@Index(["userId"])
 export class CommentLike extends AppBaseEntity {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ name: 'comment_id' })
+  @Column({ name: "comment_id" })
   commentId: string;
 
-  @ManyToOne(() => Comment, (comment) => comment.likes, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'comment_id' })
+  @ManyToOne(() => Comment, (comment) => comment.likes, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "comment_id" })
   comment: Comment;
 
-  @Column({ name: 'user_id' })
+  @Column({ name: "user_id" })
   userId: string;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'user_id' })
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
   user: User;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: "updated_at" })
   updatedAt: Date;
 }

--- a/backend/src/comments/comment-query.builder.ts
+++ b/backend/src/comments/comment-query.builder.ts
@@ -1,0 +1,215 @@
+import { BadRequestException } from "@nestjs/common";
+import { Brackets, Repository, SelectQueryBuilder } from "typeorm";
+import { Comment } from "./comment.entity";
+import { CommentSortMode } from "./comment.dto";
+
+interface CommentCursorPayload {
+  id: string;
+  createdAt: string;
+  likesCount: number;
+  sort: CommentSortMode;
+}
+
+interface TopLevelCommentQueryOptions {
+  blockedUserIds: string[];
+  cursor?: string;
+  limit: number;
+  sort: CommentSortMode;
+  trackId: string;
+}
+
+interface BoundedReplyQueryOptions {
+  blockedUserIds: string[];
+  parentIds: string[];
+  replyLimit: number;
+}
+
+export class CommentQueryBuilder {
+  constructor(private readonly commentRepository: Repository<Comment>) {}
+
+  buildTopLevelCommentsQuery({
+    blockedUserIds,
+    cursor,
+    limit,
+    sort,
+    trackId,
+  }: TopLevelCommentQueryOptions): SelectQueryBuilder<Comment> {
+    const queryBuilder = this.commentRepository
+      .createQueryBuilder("comment")
+      .where("comment.trackId = :trackId", { trackId })
+      .andWhere("comment.parentCommentId IS NULL")
+      .take(limit);
+
+    if (blockedUserIds.length > 0) {
+      queryBuilder.andWhere("comment.userId NOT IN (:...blockedUserIds)", {
+        blockedUserIds,
+      });
+    }
+
+    this.applySort(queryBuilder, sort);
+    this.applyCursor(queryBuilder, cursor, sort);
+
+    return queryBuilder;
+  }
+
+  async findBoundedReplyIds({
+    blockedUserIds,
+    parentIds,
+    replyLimit,
+  }: BoundedReplyQueryOptions): Promise<string[]> {
+    if (parentIds.length === 0 || replyLimit <= 0) {
+      return [];
+    }
+
+    const params: unknown[] = [parentIds, replyLimit];
+    const blockedUserFilter =
+      blockedUserIds.length > 0 ? `AND NOT (c.user_id = ANY($3::uuid[]))` : "";
+
+    if (blockedUserIds.length > 0) {
+      params.push(blockedUserIds);
+    }
+
+    const rows = await this.commentRepository.query(
+      `
+        SELECT ranked.id
+        FROM (
+          SELECT
+            c.id,
+            c.parent_comment_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY c.parent_comment_id
+              ORDER BY c.created_at ASC, c.id ASC
+            ) AS reply_rank
+          FROM comments c
+          WHERE c.parent_comment_id = ANY($1::uuid[])
+            ${blockedUserFilter}
+        ) AS ranked
+        WHERE ranked.reply_rank <= $2
+        ORDER BY ranked.parent_comment_id ASC, ranked.reply_rank ASC
+      `,
+      params,
+    );
+
+    return rows.map((row: { id: string }) => row.id);
+  }
+
+  encodeCursor(
+    comment: Pick<Comment, "id" | "createdAt" | "likesCount">,
+    sort: CommentSortMode,
+  ): string {
+    const payload: CommentCursorPayload = {
+      id: comment.id,
+      createdAt: comment.createdAt.toISOString(),
+      likesCount: comment.likesCount,
+      sort,
+    };
+
+    return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  }
+
+  private applyCursor(
+    queryBuilder: SelectQueryBuilder<Comment>,
+    cursor: string | undefined,
+    sort: CommentSortMode,
+  ): void {
+    if (!cursor) {
+      return;
+    }
+
+    const decodedCursor = this.decodeCursor(cursor, sort);
+    const cursorCreatedAt = new Date(decodedCursor.createdAt);
+
+    if (sort === CommentSortMode.MOST_LIKED) {
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          qb.where("comment.likesCount < :cursorLikesCount", {
+            cursorLikesCount: decodedCursor.likesCount,
+          }).orWhere(
+            new Brackets((sameLikesQb) => {
+              sameLikesQb
+                .where("comment.likesCount = :cursorLikesCount", {
+                  cursorLikesCount: decodedCursor.likesCount,
+                })
+                .andWhere(
+                  new Brackets((sameCreatedAtQb) => {
+                    sameCreatedAtQb
+                      .where("comment.createdAt < :cursorCreatedAt", {
+                        cursorCreatedAt,
+                      })
+                      .orWhere(
+                        "comment.createdAt = :cursorCreatedAt AND comment.id < :cursorId",
+                        {
+                          cursorCreatedAt,
+                          cursorId: decodedCursor.id,
+                        },
+                      );
+                  }),
+                );
+            }),
+          );
+        }),
+      );
+
+      return;
+    }
+
+    queryBuilder.andWhere(
+      new Brackets((qb) => {
+        qb.where("comment.createdAt < :cursorCreatedAt", {
+          cursorCreatedAt,
+        }).orWhere(
+          "comment.createdAt = :cursorCreatedAt AND comment.id < :cursorId",
+          {
+            cursorCreatedAt,
+            cursorId: decodedCursor.id,
+          },
+        );
+      }),
+    );
+  }
+
+  private applySort(
+    queryBuilder: SelectQueryBuilder<Comment>,
+    sort: CommentSortMode,
+  ): void {
+    if (sort === CommentSortMode.MOST_LIKED) {
+      queryBuilder
+        .orderBy("comment.likesCount", "DESC")
+        .addOrderBy("comment.createdAt", "DESC")
+        .addOrderBy("comment.id", "DESC");
+      return;
+    }
+
+    queryBuilder
+      .orderBy("comment.createdAt", "DESC")
+      .addOrderBy("comment.id", "DESC");
+  }
+
+  private decodeCursor(
+    cursor: string,
+    expectedSort: CommentSortMode,
+  ): CommentCursorPayload {
+    try {
+      const decoded = JSON.parse(
+        Buffer.from(cursor, "base64url").toString("utf8"),
+      ) as CommentCursorPayload;
+
+      if (
+        !decoded.id ||
+        !decoded.createdAt ||
+        typeof decoded.likesCount !== "number" ||
+        !Object.values(CommentSortMode).includes(decoded.sort)
+      ) {
+        throw new Error("Malformed cursor");
+      }
+
+      if (decoded.sort !== expectedSort) {
+        throw new Error("Cursor sort mismatch");
+      }
+
+      return decoded;
+    } catch {
+      throw new BadRequestException("Invalid comment cursor");
+    }
+  }
+}

--- a/backend/src/comments/comment.dto.ts
+++ b/backend/src/comments/comment.dto.ts
@@ -1,5 +1,17 @@
-import { IsString, IsNotEmpty, IsOptional, IsUUID, MaxLength } from 'class-validator';
-import { SanitiseAsPlainText } from '../common/utils/sanitise.util';
+import { Type } from "class-transformer";
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from "class-validator";
+import { SanitiseAsPlainText } from "../common/utils/sanitise.util";
+import { Comment } from "./comment.entity";
 
 export class CreateCommentDto {
   @IsUUID()
@@ -25,10 +37,40 @@ export class UpdateCommentDto {
   content: string;
 }
 
+export enum CommentSortMode {
+  NEWEST = "newest",
+  MOST_LIKED = "most-liked",
+}
+
 export class PaginationQueryDto {
   @IsOptional()
-  page?: number = 1;
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
 
   @IsOptional()
-  limit?: number = 20;
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @IsEnum(CommentSortMode)
+  sort?: CommentSortMode = CommentSortMode.NEWEST;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(10)
+  replyLimit?: number = 3;
+}
+
+export interface CommentFeedResponse {
+  comments: Comment[];
+  limit: number;
+  replyLimit: number;
+  sort: CommentSortMode;
+  nextCursor: string | null;
+  hasMore: boolean;
 }

--- a/backend/src/comments/comment.entity.ts
+++ b/backend/src/comments/comment.entity.ts
@@ -7,42 +7,46 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   JoinColumn,
-} from 'typeorm';
-import { Track } from '../tracks/entities/track.entity';
-import { User } from '../users/entities/user.entity';
-import { CommentLike } from './comment-like.entity';
-import { AppBaseEntity } from '../common/entities/base.entity';
+  Index,
+} from "typeorm";
+import { Track } from "../tracks/entities/track.entity";
+import { User } from "../users/entities/user.entity";
+import { CommentLike } from "./comment-like.entity";
+import { AppBaseEntity } from "../common/entities/base.entity";
 
-@Entity('comments')
+@Entity("comments")
+@Index(["trackId", "parentCommentId", "createdAt"])
+@Index(["trackId", "parentCommentId", "likesCount", "createdAt"])
+@Index(["parentCommentId", "createdAt"])
 export class Comment extends AppBaseEntity {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ name: 'track_id' })
+  @Column({ name: "track_id" })
   trackId: string;
 
-  @ManyToOne(() => Track, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'track_id' })
+  @ManyToOne(() => Track, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "track_id" })
   track: Track;
 
-  @Column({ name: 'user_id' })
+  @Column({ name: "user_id" })
   userId: string;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'user_id' })
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
   user: User;
 
-  @Column('text')
+  @Column("text")
   content: string;
 
-  @Column({ name: 'parent_comment_id', nullable: true })
+  @Column({ name: "parent_comment_id", nullable: true })
   parentCommentId: string | null;
 
   @ManyToOne(() => Comment, (comment) => comment.replies, {
-    onDelete: 'CASCADE',
+    onDelete: "CASCADE",
     nullable: true,
   })
-  @JoinColumn({ name: 'parent_comment_id' })
+  @JoinColumn({ name: "parent_comment_id" })
   parentComment: Comment | null;
 
   @OneToMany(() => Comment, (comment) => comment.parentComment)
@@ -51,15 +55,24 @@ export class Comment extends AppBaseEntity {
   @OneToMany(() => CommentLike, (like) => like.comment)
   likes: CommentLike[];
 
-  @Column({ name: 'likes_count', default: 0 })
+  @Column({ name: "likes_count", default: 0 })
   likesCount: number;
 
-  @Column({ name: 'is_edited', default: false })
+  @Column({ name: "is_edited", default: false })
   isEdited: boolean;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @Column({ name: "deleted_at", type: "timestamp", nullable: true })
+  deletedAt: Date | null;
+
+  @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
+  @UpdateDateColumn({ name: "updated_at" })
   updatedAt: Date;
+
+  replyCount?: number;
+
+  userLiked?: boolean;
+
+  isDeleted?: boolean;
 }

--- a/backend/src/comments/comments.module.ts
+++ b/backend/src/comments/comments.module.ts
@@ -5,11 +5,12 @@ import { CommentLike } from "./comment-like.entity";
 import { CommentsService } from "./comments.service";
 import { CommentsController } from "./comments.controller";
 import { BlocksModule } from "../blocks/blocks.module";
+import { CommentLikeRepairService } from "./comment-like-repair.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment, CommentLike]), BlocksModule],
   controllers: [CommentsController],
-  providers: [CommentsService],
-  exports: [CommentsService],
+  providers: [CommentsService, CommentLikeRepairService],
+  exports: [CommentsService, CommentLikeRepairService],
 })
 export class CommentsModule {}

--- a/backend/src/comments/comments.service.spec.ts
+++ b/backend/src/comments/comments.service.spec.ts
@@ -1,40 +1,63 @@
+import { ForbiddenException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { getRepositoryToken } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
-import { CommentsService } from "./comments.service";
+import { DataSource, Repository } from "typeorm";
+import { BlocksService } from "../blocks/blocks.service";
+import { CommentSortMode } from "./comment.dto";
 import { Comment } from "./comment.entity";
 import { CommentLike } from "./comment-like.entity";
-import { BlocksService } from "../blocks/blocks.service";
-import {
-  NotFoundException,
-  ForbiddenException,
-  BadRequestException,
-} from "@nestjs/common";
+import { CommentsService } from "./comments.service";
 
 describe("CommentsService", () => {
   let service: CommentsService;
   let commentRepository: Repository<Comment>;
-  let commentLikeRepository: Repository<CommentLike>;
+  let dataSource: DataSource;
 
   const mockCommentRepository = {
     create: jest.fn(),
     save: jest.fn(),
     findOne: jest.fn(),
-    findAndCount: jest.fn(),
-    remove: jest.fn(),
+    find: jest.fn(),
+    query: jest.fn(),
+    createQueryBuilder: jest.fn(),
   };
 
   const mockCommentLikeRepository = {
-    create: jest.fn(),
-    save: jest.fn(),
-    findOne: jest.fn(),
     find: jest.fn(),
-    remove: jest.fn(),
   };
 
   const mockBlocksService = {
     getBlockedUserIds: jest.fn().mockResolvedValue([]),
   };
+
+  const mockDataSource = {
+    transaction: jest.fn(),
+  };
+
+  const createTopLevelQueryBuilder = () => ({
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    loadRelationCountAndMap: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+  });
+
+  const createMutationQueryBuilder = (executeResult: unknown) => ({
+    insert: jest.fn().mockReturnThis(),
+    into: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orIgnore: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(executeResult),
+  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -52,6 +75,10 @@ describe("CommentsService", () => {
           provide: BlocksService,
           useValue: mockBlocksService,
         },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
       ],
     }).compile();
 
@@ -59,277 +86,267 @@ describe("CommentsService", () => {
     commentRepository = module.get<Repository<Comment>>(
       getRepositoryToken(Comment),
     );
-    commentLikeRepository = module.get<Repository<CommentLike>>(
-      getRepositoryToken(CommentLike),
-    );
+    dataSource = module.get<DataSource>(DataSource);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe("create", () => {
-    it("should create a top-level comment", async () => {
-      const createDto = {
-        trackId: "track-uuid",
-        content: "Great track!",
-      };
-      const userId = "user-uuid";
-      const savedComment = {
-        id: "comment-uuid",
-        ...createDto,
-        userId,
-        parentCommentId: null,
-      };
+  it("creates a top-level comment", async () => {
+    const createDto = {
+      trackId: "track-uuid",
+      content: "Great track!",
+    };
+    const userId = "user-uuid";
+    const savedComment = {
+      id: "comment-uuid",
+      ...createDto,
+      userId,
+      parentCommentId: null,
+      deletedAt: null,
+    };
 
-      mockCommentRepository.create.mockReturnValue(savedComment);
-      mockCommentRepository.save.mockResolvedValue(savedComment);
+    mockCommentRepository.create.mockReturnValue(savedComment);
+    mockCommentRepository.save.mockResolvedValue(savedComment);
 
-      const result = await service.create(createDto, userId);
+    const result = await service.create(createDto, userId);
 
-      expect(mockCommentRepository.create).toHaveBeenCalledWith({
-        trackId: createDto.trackId,
-        userId,
-        content: createDto.content,
-        parentCommentId: null,
-      });
-      expect(result).toEqual(savedComment);
+    expect(mockCommentRepository.create).toHaveBeenCalledWith({
+      trackId: createDto.trackId,
+      userId,
+      content: createDto.content,
+      parentCommentId: null,
+      deletedAt: null,
     });
-
-    it("should create a reply comment", async () => {
-      const parentComment = {
-        id: "parent-uuid",
-        parentCommentId: null,
-      };
-      const createDto = {
-        trackId: "track-uuid",
-        content: "I agree!",
-        parentCommentId: "parent-uuid",
-      };
-      const userId = "user-uuid";
-
-      mockCommentRepository.findOne.mockResolvedValue(parentComment);
-      mockCommentRepository.create.mockReturnValue(createDto);
-      mockCommentRepository.save.mockResolvedValue(createDto);
-
-      await service.create(createDto, userId);
-
-      expect(mockCommentRepository.findOne).toHaveBeenCalledWith({
-        where: { id: "parent-uuid" },
-        relations: ["parentComment"],
-      });
-    });
-
-    it("should throw error when replying to a reply", async () => {
-      const parentComment = {
-        id: "parent-uuid",
-        parentCommentId: "grandparent-uuid",
-      };
-      const createDto = {
-        trackId: "track-uuid",
-        content: "Reply to reply",
-        parentCommentId: "parent-uuid",
-      };
-
-      mockCommentRepository.findOne.mockResolvedValue(parentComment);
-
-      await expect(service.create(createDto, "user-uuid")).rejects.toThrow(
-        BadRequestException,
-      );
-    });
-
-    it("should throw error when parent comment not found", async () => {
-      const createDto = {
-        trackId: "track-uuid",
-        content: "Reply",
-        parentCommentId: "non-existent",
-      };
-
-      mockCommentRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.create(createDto, "user-uuid")).rejects.toThrow(
-        NotFoundException,
-      );
-    });
+    expect(result).toEqual(savedComment);
   });
 
-  describe("findByTrack", () => {
-    it("should return paginated comments for a track", async () => {
-      const trackId = "track-uuid";
-      const comments = [
-        { id: "comment-1", content: "Comment 1", replies: [] },
-        { id: "comment-2", content: "Comment 2", replies: [] },
-      ];
-      const query = { page: 1, limit: 20 };
+  it("returns cursor-paginated comments with bounded replies and sort metadata", async () => {
+    const createdAt = new Date("2026-04-25T17:00:00.000Z");
+    const topLevelQueryBuilder = createTopLevelQueryBuilder();
+    const topLevelComments = [
+      {
+        id: "comment-3",
+        content: "Third",
+        createdAt: new Date("2026-04-25T16:59:00.000Z"),
+        likesCount: 9,
+        replyCount: 4,
+        replies: [],
+      },
+      {
+        id: "comment-2",
+        content: "Second",
+        createdAt,
+        likesCount: 7,
+        replyCount: 2,
+        replies: [],
+      },
+      {
+        id: "comment-1",
+        content: "First",
+        createdAt: new Date("2026-04-25T16:58:00.000Z"),
+        likesCount: 5,
+        replyCount: 1,
+        replies: [],
+      },
+    ];
+    const hydratedReplies = [
+      {
+        id: "reply-2",
+        parentCommentId: "comment-2",
+        content: "Reply 2",
+        createdAt: new Date("2026-04-25T17:02:00.000Z"),
+      },
+      {
+        id: "reply-1",
+        parentCommentId: "comment-3",
+        content: "Reply 1",
+        createdAt: new Date("2026-04-25T17:01:00.000Z"),
+      },
+    ];
 
-      mockCommentRepository.findAndCount.mockResolvedValue([comments, 2]);
-      mockCommentLikeRepository.find.mockResolvedValue([]);
+    topLevelQueryBuilder.getMany.mockResolvedValue(topLevelComments);
+    mockCommentRepository.createQueryBuilder.mockReturnValue(
+      topLevelQueryBuilder,
+    );
+    mockCommentRepository.query.mockResolvedValue([
+      { id: "reply-1" },
+      { id: "reply-2" },
+    ]);
+    mockCommentRepository.find.mockResolvedValue(hydratedReplies);
+    mockCommentLikeRepository.find.mockResolvedValue([
+      { commentId: "comment-3" },
+      { commentId: "reply-2" },
+    ]);
 
-      const result = await service.findByTrack(trackId, query);
+    const result = await service.findByTrack(
+      "track-uuid",
+      {
+        limit: 2,
+        replyLimit: 1,
+        sort: CommentSortMode.MOST_LIKED,
+      },
+      "viewer-uuid",
+    );
 
-      expect(result.comments).toHaveLength(2);
-      expect(result.total).toBe(2);
-      expect(result.page).toBe(1);
-      expect(result.limit).toBe(20);
-    });
+    expect(result.comments).toHaveLength(2);
+    expect(result.hasMore).toBe(true);
+    expect(result.sort).toBe(CommentSortMode.MOST_LIKED);
+    expect(result.replyLimit).toBe(1);
+    expect(result.nextCursor).toBeTruthy();
+    expect(result.comments[0].replyCount).toBe(4);
+    expect(result.comments[0].replies).toHaveLength(1);
+    expect(result.comments[0].userLiked).toBe(true);
+    expect(result.comments[1].replies[0].userLiked).toBe(true);
+    expect(topLevelQueryBuilder.orderBy).toHaveBeenCalledWith(
+      "comment.likesCount",
+      "DESC",
+    );
+    expect(mockCommentRepository.query).toHaveBeenCalledWith(
+      expect.stringContaining("ROW_NUMBER() OVER"),
+      [["comment-3", "comment-2"], 1],
+    );
   });
 
-  describe("update", () => {
-    it("should update a comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const updateDto = { content: "Updated content" };
-      const comment = {
-        id: commentId,
-        userId,
-        content: "Original content",
+  it("renders deleted parent comments as placeholders while preserving replies", async () => {
+    mockCommentRepository.findOne.mockResolvedValue({
+      id: "comment-uuid",
+      content: "original content",
+      deletedAt: new Date("2026-04-25T17:00:00.000Z"),
+      isEdited: true,
+      createdAt: new Date("2026-04-25T16:59:00.000Z"),
+      replies: [
+        {
+          id: "reply-uuid",
+          content: "Still visible",
+          createdAt: new Date("2026-04-25T17:01:00.000Z"),
+          deletedAt: null,
+        },
+      ],
+    });
+    mockCommentLikeRepository.find.mockResolvedValue([]);
+
+    const result = await service.findOne("comment-uuid", "viewer-uuid");
+
+    expect(result.content).toBe("[deleted]");
+    expect(result.isDeleted).toBe(true);
+    expect(result.replyCount).toBe(1);
+    expect(result.replies[0].content).toBe("Still visible");
+  });
+
+  it("soft deletes a comment instead of removing the row", async () => {
+    const comment = {
+      id: "comment-uuid",
+      userId: "user-uuid",
+      content: "Keep replies",
+      deletedAt: null,
+    };
+
+    mockCommentRepository.findOne.mockResolvedValue(comment);
+    mockCommentRepository.save.mockResolvedValue({
+      ...comment,
+      deletedAt: new Date(),
+      content: "[deleted]",
+    });
+
+    await service.delete("comment-uuid", "user-uuid");
+
+    expect(mockCommentRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "[deleted]",
         isEdited: false,
-      };
+      }),
+    );
+  });
 
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentRepository.save.mockResolvedValue({
-        ...comment,
-        ...updateDto,
-        isEdited: true,
-      });
-
-      const result = await service.update(commentId, updateDto, userId);
-
-      expect(result.content).toBe(updateDto.content);
-      expect(result.isEdited).toBe(true);
+  it("prevents deleting someone else's comment", async () => {
+    mockCommentRepository.findOne.mockResolvedValue({
+      id: "comment-uuid",
+      userId: "owner-uuid",
+      deletedAt: null,
     });
 
-    it("should throw error when updating others comment", async () => {
-      const commentId = "comment-uuid";
-      const comment = {
-        id: commentId,
-        userId: "owner-uuid",
-      };
+    await expect(service.delete("comment-uuid", "other-user")).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
 
-      mockCommentRepository.findOne.mockResolvedValue(comment);
+  it("increments likes atomically when a new like is inserted", async () => {
+    const insertBuilder = createMutationQueryBuilder({
+      affected: 1,
+      identifiers: [{ id: "like-uuid" }],
+      raw: [],
+    });
+    const updateBuilder = createMutationQueryBuilder({ affected: 1 });
 
-      await expect(
-        service.update(commentId, { content: "New" }, "other-user"),
-      ).rejects.toThrow(ForbiddenException);
+    mockCommentRepository.findOne.mockResolvedValue({ id: "comment-uuid" });
+    mockDataSource.transaction.mockImplementation(async (callback) =>
+      callback({
+        createQueryBuilder: jest
+          .fn()
+          .mockReturnValueOnce(insertBuilder)
+          .mockReturnValueOnce(updateBuilder),
+      }),
+    );
+    jest.spyOn(service, "findOne").mockResolvedValue({
+      id: "comment-uuid",
+      likesCount: 1,
+    } as Comment);
+
+    const result = await service.likeComment("comment-uuid", "user-uuid");
+
+    expect(result.likesCount).toBe(1);
+    expect(insertBuilder.orIgnore).toHaveBeenCalled();
+    expect(updateBuilder.set).toHaveBeenCalledWith({
+      likesCount: expect.any(Function),
     });
   });
 
-  describe("delete", () => {
-    it("should delete a comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const comment = {
-        id: commentId,
-        userId,
-      };
-
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentRepository.remove.mockResolvedValue(comment);
-
-      await service.delete(commentId, userId);
-
-      expect(mockCommentRepository.remove).toHaveBeenCalledWith(comment);
+  it("treats duplicate likes as idempotent and does not increment the counter", async () => {
+    const insertBuilder = createMutationQueryBuilder({
+      affected: 0,
+      identifiers: [],
+      raw: [],
     });
 
-    it("should throw error when deleting others comment", async () => {
-      const commentId = "comment-uuid";
-      const comment = {
-        id: commentId,
-        userId: "owner-uuid",
-      };
+    mockCommentRepository.findOne.mockResolvedValue({ id: "comment-uuid" });
+    mockDataSource.transaction.mockImplementation(async (callback) =>
+      callback({
+        createQueryBuilder: jest.fn().mockReturnValue(insertBuilder),
+      }),
+    );
+    jest.spyOn(service, "findOne").mockResolvedValue({
+      id: "comment-uuid",
+      likesCount: 1,
+    } as Comment);
 
-      mockCommentRepository.findOne.mockResolvedValue(comment);
+    const result = await service.likeComment("comment-uuid", "user-uuid");
 
-      await expect(service.delete(commentId, "other-user")).rejects.toThrow(
-        ForbiddenException,
-      );
-    });
+    expect(result.likesCount).toBe(1);
+    expect(dataSource.transaction).toHaveBeenCalled();
   });
 
-  describe("likeComment", () => {
-    it("should like a comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const comment = {
-        id: commentId,
-        likesCount: 0,
-      };
-
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentLikeRepository.findOne.mockResolvedValue(null);
-      mockCommentLikeRepository.create.mockReturnValue({ commentId, userId });
-      mockCommentLikeRepository.save.mockResolvedValue({ commentId, userId });
-      mockCommentRepository.save.mockResolvedValue({
-        ...comment,
-        likesCount: 1,
-      });
-
-      // Mock findOne for final result
-      jest.spyOn(service, "findOne").mockResolvedValue({
-        ...comment,
-        likesCount: 1,
-      } as any);
-
-      const result = await service.likeComment(commentId, userId);
-
-      expect(result.likesCount).toBe(1);
+  it("treats duplicate unlikes as idempotent and never decrements below zero", async () => {
+    const deleteBuilder = createMutationQueryBuilder({
+      affected: 0,
+      raw: [],
     });
 
-    it("should throw error when liking already liked comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const comment = { id: commentId, likesCount: 1 };
-      const existingLike = { id: "like-uuid", commentId, userId };
+    mockCommentRepository.findOne.mockResolvedValue({ id: "comment-uuid" });
+    mockDataSource.transaction.mockImplementation(async (callback) =>
+      callback({
+        createQueryBuilder: jest.fn().mockReturnValue(deleteBuilder),
+      }),
+    );
+    jest.spyOn(service, "findOne").mockResolvedValue({
+      id: "comment-uuid",
+      likesCount: 0,
+    } as Comment);
 
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentLikeRepository.findOne.mockResolvedValue(existingLike);
+    const result = await service.unlikeComment("comment-uuid", "user-uuid");
 
-      await expect(service.likeComment(commentId, userId)).rejects.toThrow(
-        BadRequestException,
-      );
-    });
-  });
-
-  describe("unlikeComment", () => {
-    it("should unlike a comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const comment = {
-        id: commentId,
-        likesCount: 1,
-      };
-      const like = { id: "like-uuid", commentId, userId };
-
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentLikeRepository.findOne.mockResolvedValue(like);
-      mockCommentLikeRepository.remove.mockResolvedValue(like);
-      mockCommentRepository.save.mockResolvedValue({
-        ...comment,
-        likesCount: 0,
-      });
-
-      // Mock findOne for final result
-      jest.spyOn(service, "findOne").mockResolvedValue({
-        ...comment,
-        likesCount: 0,
-      } as any);
-
-      const result = await service.unlikeComment(commentId, userId);
-
-      expect(result.likesCount).toBe(0);
-    });
-
-    it("should throw error when unliking non-liked comment", async () => {
-      const commentId = "comment-uuid";
-      const userId = "user-uuid";
-      const comment = { id: commentId, likesCount: 0 };
-
-      mockCommentRepository.findOne.mockResolvedValue(comment);
-      mockCommentLikeRepository.findOne.mockResolvedValue(null);
-
-      await expect(service.unlikeComment(commentId, userId)).rejects.toThrow(
-        BadRequestException,
-      );
-    });
+    expect(result.likesCount).toBe(0);
+    expect(dataSource.transaction).toHaveBeenCalled();
   });
 });

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -1,31 +1,45 @@
 import {
+  BadRequestException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
-  ForbiddenException,
-  BadRequestException,
 } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import {
+  DataSource,
+  DeleteResult,
+  In,
+  InsertResult,
+  Repository,
+} from "typeorm";
+import { BlocksService } from "../blocks/blocks.service";
+import {
+  CommentFeedResponse,
+  CommentSortMode,
+  CreateCommentDto,
+  PaginationQueryDto,
+  UpdateCommentDto,
+} from "./comment.dto";
 import { Comment } from "./comment.entity";
 import { CommentLike } from "./comment-like.entity";
-import {
-  CreateCommentDto,
-  UpdateCommentDto,
-  PaginationQueryDto,
-} from "./comment.dto";
-import { PaginatedResponse } from '../common/dto/paginated-response.dto';
-import { paginate } from '../common/helpers/paginate.helper';
-import { BlocksService } from "../blocks/blocks.service";
+import { CommentQueryBuilder } from "./comment-query.builder";
+
+const COMMENT_DELETED_PLACEHOLDER = "[deleted]";
 
 @Injectable()
 export class CommentsService {
+  private readonly commentQueryBuilder: CommentQueryBuilder;
+
   constructor(
     @InjectRepository(Comment)
-    private commentRepository: Repository<Comment>,
+    private readonly commentRepository: Repository<Comment>,
     @InjectRepository(CommentLike)
-    private commentLikeRepository: Repository<CommentLike>,
+    private readonly commentLikeRepository: Repository<CommentLike>,
     private readonly blocksService: BlocksService,
-  ) {}
+    private readonly dataSource: DataSource,
+  ) {
+    this.commentQueryBuilder = new CommentQueryBuilder(this.commentRepository);
+  }
 
   async create(
     createCommentDto: CreateCommentDto,
@@ -33,7 +47,6 @@ export class CommentsService {
   ): Promise<Comment> {
     const { trackId, content, parentCommentId } = createCommentDto;
 
-    // If it's a reply, validate parent comment exists and check nesting level
     if (parentCommentId) {
       const parentComment = await this.commentRepository.findOne({
         where: { id: parentCommentId },
@@ -44,7 +57,6 @@ export class CommentsService {
         throw new NotFoundException("Parent comment not found");
       }
 
-      // Check if parent is already a reply (enforce 2-level limit)
       if (parentComment.parentCommentId) {
         throw new BadRequestException(
           "Cannot reply to a reply. Maximum nesting level is 2.",
@@ -57,92 +69,107 @@ export class CommentsService {
       userId,
       content,
       parentCommentId: parentCommentId || null,
+      deletedAt: null,
     });
 
-    return await this.commentRepository.save(comment);
+    return this.commentRepository.save(comment);
   }
 
   async findByTrack(
     trackId: string,
     query: PaginationQueryDto,
     userId?: string,
-  ): Promise<{
-    comments: Comment[];
-    total: number;
-    page: number;
-    limit: number;
-  }> {
-    const page = Number(query.page) || 1;
-    const limit = Number(query.limit) || 20;
-    const skip = (page - 1) * limit;
+  ): Promise<CommentFeedResponse> {
+    const limit = this.normalizeLimit(query.limit);
+    const replyLimit = this.normalizeReplyLimit(query.replyLimit);
+    const sort = query.sort ?? CommentSortMode.NEWEST;
+    const blockedUserIds = userId
+      ? await this.blocksService.getBlockedUserIds(userId)
+      : [];
 
-    // Get blocked user IDs to filter out their comments (if viewing as artist)
-    let blockedUserIds: string[] = [];
-    if (userId) {
-      blockedUserIds = await this.blocksService.getBlockedUserIds(userId);
-    }
+    const topLevelQuery = this.commentQueryBuilder.buildTopLevelCommentsQuery({
+      trackId,
+      limit: limit + 1,
+      sort,
+      cursor: query.cursor,
+      blockedUserIds,
+    });
 
-    // Build query to get top-level comments, excluding blocked users
-    const queryBuilder = this.commentRepository
-      .createQueryBuilder("comment")
+    topLevelQuery
       .leftJoinAndSelect("comment.user", "user")
-      .leftJoinAndSelect("comment.replies", "replies")
-      .leftJoinAndSelect("replies.user", "replyUser")
-      .leftJoinAndSelect("comment.likes", "likes")
-      .where("comment.trackId = :trackId", { trackId })
-      .andWhere("comment.parentCommentId IS NULL")
-      .orderBy("comment.createdAt", "DESC")
-      .addOrderBy("replies.createdAt", "ASC")
-      .skip(skip)
-      .take(limit);
+      .loadRelationCountAndMap(
+        "comment.replyCount",
+        "comment.replies",
+        "replyCount",
+        (replyCountQb) => {
+          if (blockedUserIds.length > 0) {
+            replyCountQb.andWhere(
+              "replyCount.userId NOT IN (:...blockedUserIds)",
+              {
+                blockedUserIds,
+              },
+            );
+          }
 
-    // Exclude comments from blocked users
-    if (blockedUserIds.length > 0) {
-      queryBuilder.andWhere("comment.userId NOT IN (:...blockedUserIds)", {
-        blockedUserIds,
-      });
-    }
+          return replyCountQb;
+        },
+      );
 
-    const [comments, total] = await queryBuilder.getManyAndCount();
-
-    // Filter out replies from blocked users
-    const filteredComments = comments.map((comment) => ({
-      ...comment,
-      replies:
-        comment.replies?.filter(
-          (reply) => !blockedUserIds.includes(reply.userId),
-        ) || [],
-    })) as Comment[];
-
-    // Add userLiked flag if userId is provided
-    const commentsWithLikeStatus = await this.addUserLikedStatus(
-      filteredComments,
-      userId,
+    const topLevelComments = await topLevelQuery.getMany();
+    const hasMore = topLevelComments.length > limit;
+    const pageComments = hasMore
+      ? topLevelComments.slice(0, limit)
+      : topLevelComments;
+    const repliesByParentId = await this.loadBoundedReplies(
+      pageComments.map((comment) => comment.id),
+      replyLimit,
+      blockedUserIds,
     );
 
+    const commentsWithReplies = pageComments.map((comment) => ({
+      ...comment,
+      replies: repliesByParentId.get(comment.id) || [],
+    })) as Comment[];
+    const commentsWithLikeStatus = await this.addUserLikedStatus(
+      commentsWithReplies,
+      userId,
+    );
+    const visibleComments = commentsWithLikeStatus.map((comment) =>
+      this.presentComment(comment),
+    );
+    const lastVisibleComment = visibleComments[visibleComments.length - 1];
+
     return {
-      comments: commentsWithLikeStatus,
-      total,
-      page,
+      comments: visibleComments,
       limit,
+      replyLimit,
+      sort,
+      nextCursor:
+        hasMore && lastVisibleComment
+          ? this.commentQueryBuilder.encodeCursor(lastVisibleComment, sort)
+          : null,
+      hasMore,
     };
   }
 
   async findOne(id: string, userId?: string): Promise<Comment> {
     const comment = await this.commentRepository.findOne({
       where: { id },
-      relations: ["user", "replies", "replies.user", "likes"],
+      relations: ["user", "replies", "replies.user"],
     });
 
     if (!comment) {
       throw new NotFoundException("Comment not found");
     }
 
+    comment.replies = this.sortReplies(comment.replies || []);
+    comment.replyCount = comment.replies.length;
+
     const [commentWithStatus] = await this.addUserLikedStatus(
       [comment],
       userId,
     );
-    return commentWithStatus;
+    return this.presentComment(commentWithStatus);
   }
 
   async update(
@@ -160,10 +187,14 @@ export class CommentsService {
       throw new ForbiddenException("You can only edit your own comments");
     }
 
+    if (comment.deletedAt) {
+      throw new BadRequestException("Deleted comments cannot be edited");
+    }
+
     comment.content = updateCommentDto.content;
     comment.isEdited = true;
 
-    return await this.commentRepository.save(comment);
+    return this.commentRepository.save(comment);
   }
 
   async delete(id: string, userId: string): Promise<void> {
@@ -177,39 +208,71 @@ export class CommentsService {
       throw new ForbiddenException("You can only delete your own comments");
     }
 
-    await this.commentRepository.remove(comment);
+    if (comment.deletedAt) {
+      return;
+    }
+
+    comment.deletedAt = new Date();
+    comment.content = COMMENT_DELETED_PLACEHOLDER;
+    comment.isEdited = false;
+    await this.commentRepository.save(comment);
   }
 
   async likeComment(commentId: string, userId: string): Promise<Comment> {
-    const comment = await this.commentRepository.findOne({
-      where: { id: commentId },
+    await this.ensureCommentExists(commentId);
+
+    await this.dataSource.transaction(async (manager) => {
+      const insertResult = await manager
+        .createQueryBuilder()
+        .insert()
+        .into(CommentLike)
+        .values({ commentId, userId })
+        .orIgnore()
+        .execute();
+
+      if (!this.didAffectRows(insertResult)) {
+        return;
+      }
+
+      await manager
+        .createQueryBuilder()
+        .update(Comment)
+        .set({ likesCount: () => '"likes_count" + 1' })
+        .where("id = :commentId", { commentId })
+        .execute();
     });
 
-    if (!comment) {
-      throw new NotFoundException("Comment not found");
-    }
-
-    // Check if already liked
-    const existingLike = await this.commentLikeRepository.findOne({
-      where: { commentId, userId },
-    });
-
-    if (existingLike) {
-      throw new BadRequestException("Comment already liked");
-    }
-
-    // Create like
-    const like = this.commentLikeRepository.create({ commentId, userId });
-    await this.commentLikeRepository.save(like);
-
-    // Increment likes count
-    comment.likesCount += 1;
-    await this.commentRepository.save(comment);
-
-    return await this.findOne(commentId, userId);
+    return this.findOne(commentId, userId);
   }
 
   async unlikeComment(commentId: string, userId: string): Promise<Comment> {
+    await this.ensureCommentExists(commentId);
+
+    await this.dataSource.transaction(async (manager) => {
+      const deleteResult = await manager
+        .createQueryBuilder()
+        .delete()
+        .from(CommentLike)
+        .where("comment_id = :commentId", { commentId })
+        .andWhere("user_id = :userId", { userId })
+        .execute();
+
+      if (!this.didAffectRows(deleteResult)) {
+        return;
+      }
+
+      await manager
+        .createQueryBuilder()
+        .update(Comment)
+        .set({ likesCount: () => 'GREATEST(0, "likes_count" - 1)' })
+        .where("id = :commentId", { commentId })
+        .execute();
+    });
+
+    return this.findOne(commentId, userId);
+  }
+
+  private async ensureCommentExists(commentId: string): Promise<void> {
     const comment = await this.commentRepository.findOne({
       where: { id: commentId },
     });
@@ -217,22 +280,47 @@ export class CommentsService {
     if (!comment) {
       throw new NotFoundException("Comment not found");
     }
+  }
 
-    const like = await this.commentLikeRepository.findOne({
-      where: { commentId, userId },
-    });
-
-    if (!like) {
-      throw new BadRequestException("Comment not liked");
+  private async loadBoundedReplies(
+    parentIds: string[],
+    replyLimit: number,
+    blockedUserIds: string[],
+  ): Promise<Map<string, Comment[]>> {
+    if (parentIds.length === 0 || replyLimit <= 0) {
+      return new Map();
     }
 
-    await this.commentLikeRepository.remove(like);
+    const replyIds = await this.commentQueryBuilder.findBoundedReplyIds({
+      parentIds,
+      replyLimit,
+      blockedUserIds,
+    });
 
-    // Decrement likes count
-    comment.likesCount = Math.max(0, comment.likesCount - 1);
-    await this.commentRepository.save(comment);
+    if (replyIds.length === 0) {
+      return new Map();
+    }
 
-    return await this.findOne(commentId, userId);
+    const replies = await this.commentRepository.find({
+      where: { id: In(replyIds) },
+      relations: ["user"],
+    });
+
+    const sortedReplies = this.sortReplies(replies);
+    const repliesByParentId = new Map<string, Comment[]>();
+
+    for (const reply of sortedReplies) {
+      reply.replyCount = 0;
+      const parentReplies = repliesByParentId.get(reply.parentCommentId || "");
+      if (parentReplies) {
+        parentReplies.push(reply);
+        continue;
+      }
+
+      repliesByParentId.set(reply.parentCommentId || "", [reply]);
+    }
+
+    return repliesByParentId;
   }
 
   private async addUserLikedStatus(
@@ -250,14 +338,19 @@ export class CommentsService {
       })) as Comment[];
     }
 
-    const commentIds = comments.map((c) => c.id);
-    const replyIds = comments.flatMap((c) => c.replies?.map((r) => r.id) || []);
+    const commentIds = comments.map((comment) => comment.id);
+    const replyIds = comments.flatMap(
+      (comment) => comment.replies?.map((reply) => reply.id) || [],
+    );
     const allIds = [...commentIds, ...replyIds];
+
+    if (allIds.length === 0) {
+      return comments;
+    }
 
     const likes = await this.commentLikeRepository.find({
       where: allIds.map((id) => ({ commentId: id, userId })),
     });
-
     const likedCommentIds = new Set(likes.map((like) => like.commentId));
 
     return comments.map((comment) => ({
@@ -268,5 +361,73 @@ export class CommentsService {
         userLiked: likedCommentIds.has(reply.id),
       })),
     })) as Comment[];
+  }
+
+  private presentComment(comment: Comment): Comment {
+    const replies = this.sortReplies(comment.replies || []).map((reply) =>
+      this.presentSingleComment(reply),
+    );
+
+    return this.presentSingleComment({
+      ...comment,
+      replies,
+      replyCount: comment.replyCount ?? replies.length,
+    } as Comment);
+  }
+
+  private presentSingleComment(comment: Comment): Comment {
+    return {
+      ...comment,
+      content: comment.deletedAt
+        ? COMMENT_DELETED_PLACEHOLDER
+        : comment.content,
+      isDeleted: Boolean(comment.deletedAt),
+      isEdited: comment.deletedAt ? false : comment.isEdited,
+      userLiked: comment.userLiked ?? false,
+      replyCount: comment.replyCount ?? 0,
+      replies: comment.replies || [],
+    } as Comment;
+  }
+
+  private sortReplies(replies: Comment[]): Comment[] {
+    return [...replies].sort((left, right) => {
+      const createdAtDelta =
+        new Date(left.createdAt).getTime() -
+        new Date(right.createdAt).getTime();
+
+      if (createdAtDelta !== 0) {
+        return createdAtDelta;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+  }
+
+  private normalizeLimit(limit?: number): number {
+    return Math.min(Math.max(Number(limit) || 20, 1), 100);
+  }
+
+  private normalizeReplyLimit(replyLimit?: number): number {
+    const normalizedReplyLimit =
+      replyLimit === undefined ? 3 : Number(replyLimit);
+    return Math.min(Math.max(normalizedReplyLimit || 0, 0), 10);
+  }
+
+  private didAffectRows(result: InsertResult | DeleteResult): boolean {
+    const affected = (result as DeleteResult).affected;
+    if (typeof affected === "number") {
+      return affected > 0;
+    }
+
+    if (Array.isArray(result.raw)) {
+      return result.raw.length > 0;
+    }
+
+    if (typeof result.raw?.rowCount === "number") {
+      return result.raw.rowCount > 0;
+    }
+
+    const identifiers = (result as InsertResult).identifiers;
+    return Array.isArray(identifiers) && identifiers.length > 0;
   }
 }

--- a/backend/src/playlists/entities/playlist-change-request.entity.ts
+++ b/backend/src/playlists/entities/playlist-change-request.entity.ts
@@ -3,88 +3,90 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  UpdateDateColumn,
   ManyToOne,
   JoinColumn,
   Index,
-} from 'typeorm';
-import { Playlist } from './playlist.entity';
-import { User } from '../../users/entities/user.entity';
+} from "typeorm";
+import { Playlist } from "./playlist.entity";
+import { User } from "../../users/entities/user.entity";
 
 export enum PlaylistChangeAction {
-  ADD_TRACK = 'add_track',
-  REMOVE_TRACK = 'remove_track',
-  REORDER_TRACKS = 'reorder_tracks',
-  UPDATE_METADATA = 'update_metadata',
+  ADD_TRACK = "add_track",
+  REMOVE_TRACK = "remove_track",
+  REORDER_TRACKS = "reorder_tracks",
+  UPDATE_METADATA = "update_metadata",
 }
 
 export enum PlaylistChangeStatus {
-  PENDING = 'pending',
-  APPROVED = 'approved',
-  REJECTED = 'rejected',
-  EXPIRED = 'expired',
-  CANCELLED = 'cancelled',
+  PENDING = "pending",
+  APPROVED = "approved",
+  REJECTED = "rejected",
+  EXPIRED = "expired",
+  CANCELLED = "cancelled",
 }
 
-@Entity('playlist_change_requests')
-@Index(['playlistId', 'status'])
-@Index(['requestedById'])
-@Index(['createdAt'])
+@Entity("playlist_change_requests")
+@Index(["playlistId", "status"])
+@Index(["playlistId", "status", "expiresAt"])
+@Index(["requestedById"])
+@Index(["createdAt"])
 export class PlaylistChangeRequest {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  @Column({ type: 'uuid' })
+  @Column({ type: "uuid" })
   playlistId: string;
 
-  @Column({ type: 'uuid', name: 'requested_by_id' })
+  @Column({ type: "uuid", name: "requested_by_id" })
   requestedById: string;
 
   @Column({
-    type: 'enum',
+    type: "enum",
     enum: PlaylistChangeAction,
   })
   action: PlaylistChangeAction;
 
-  @Column({ type: 'jsonb' })
+  @Column({ type: "jsonb" })
   payload: Record<string, any>;
 
   @Column({
-    type: 'enum',
+    type: "enum",
     enum: PlaylistChangeStatus,
     default: PlaylistChangeStatus.PENDING,
   })
   status: PlaylistChangeStatus;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: "text", nullable: true })
   rejectionReason: string | null;
 
-  @Column({ type: 'uuid', name: 'reviewed_by_id', nullable: true })
+  @Column({ type: "uuid", name: "reviewed_by_id", nullable: true })
   reviewedById: string | null;
 
-  @Column({ type: 'timestamp', name: 'reviewed_at', nullable: true })
+  @Column({ type: "timestamp", name: "reviewed_at", nullable: true })
   reviewedAt: Date | null;
 
-  @Column({ type: 'timestamp', name: 'expires_at', nullable: true })
+  @Column({ type: "timestamp", name: "expires_at", nullable: true })
   expiresAt: Date | null;
 
-  @Column({ type: 'timestamp', name: 'cancelled_at', nullable: true })
+  @Column({ type: "timestamp", name: "cancelled_at", nullable: true })
   cancelledAt: Date | null;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: "created_at" })
   createdAt: Date;
 
-  @Column({ type: 'timestamp', name: 'updated_at', default: () => 'CURRENT_TIMESTAMP' })
+  @UpdateDateColumn({ type: "timestamp", name: "updated_at" })
   updatedAt: Date;
 
-  @ManyToOne(() => Playlist, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'playlistId' })
+  @ManyToOne(() => Playlist, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "playlistId" })
   playlist: Playlist;
 
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'requestedById' })
+  @ManyToOne(() => User, { onDelete: "CASCADE" })
+  @JoinColumn({ name: "requestedById" })
   requestedBy: User;
 
-  @ManyToOne(() => User, { onDelete: 'SET NULL' })
-  @JoinColumn({ name: 'reviewedById' })
+  @ManyToOne(() => User, { onDelete: "SET NULL" })
+  @JoinColumn({ name: "reviewedById" })
   reviewedBy: User | null;
 }

--- a/backend/src/playlists/playlist-change-request.validator.spec.ts
+++ b/backend/src/playlists/playlist-change-request.validator.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import {
+  PlaylistCollaborator,
+  PlaylistCollaboratorRole,
+  PlaylistCollaboratorStatus,
+} from "./entities/playlist-collaborator.entity";
+import {
+  PlaylistChangeAction,
+  PlaylistChangeStatus,
+} from "./entities/playlist-change-request.entity";
+import { PlaylistChangeRequestValidator } from "./playlist-change-request.validator";
+import { PlaylistTrack } from "./entities/playlist-track.entity";
+import { Track } from "../tracks/entities/track.entity";
+
+describe("PlaylistChangeRequestValidator", () => {
+  let validator: PlaylistChangeRequestValidator;
+
+  const collaboratorRepository = {
+    findOne: jest.fn(),
+  };
+
+  const playlistTrackRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const trackRepository = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlaylistChangeRequestValidator,
+        {
+          provide: getRepositoryToken(PlaylistCollaborator),
+          useValue: collaboratorRepository,
+        },
+        {
+          provide: getRepositoryToken(PlaylistTrack),
+          useValue: playlistTrackRepository,
+        },
+        {
+          provide: getRepositoryToken(Track),
+          useValue: trackRepository,
+        },
+      ],
+    }).compile();
+
+    validator = module.get<PlaylistChangeRequestValidator>(
+      PlaylistChangeRequestValidator,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("marks expired requests as expired", async () => {
+    const result = await validator.validateForApproval(
+      {
+        id: "playlist-1",
+        userId: "owner-1",
+        smartPlaylist: null,
+      } as any,
+      {
+        id: "change-1",
+        playlistId: "playlist-1",
+        requestedById: "editor-1",
+        action: PlaylistChangeAction.ADD_TRACK,
+        payload: { trackId: "track-1" },
+        expiresAt: new Date("2026-04-24T00:00:00.000Z"),
+      } as any,
+    );
+
+    expect(result).toEqual({
+      isValid: false,
+      status: PlaylistChangeStatus.EXPIRED,
+      rejectionReason: "Change request has expired",
+    });
+  });
+
+  it("rejects requests when the requester has lost edit access", async () => {
+    collaboratorRepository.findOne.mockResolvedValue({
+      role: PlaylistCollaboratorRole.VIEWER,
+      status: PlaylistCollaboratorStatus.ACCEPTED,
+    });
+
+    const result = await validator.validateForApproval(
+      {
+        id: "playlist-1",
+        userId: "owner-1",
+        smartPlaylist: null,
+      } as any,
+      {
+        id: "change-1",
+        playlistId: "playlist-1",
+        requestedById: "editor-1",
+        action: PlaylistChangeAction.ADD_TRACK,
+        payload: { trackId: "track-1" },
+        expiresAt: null,
+      } as any,
+    );
+
+    expect(result).toEqual({
+      isValid: false,
+      status: PlaylistChangeStatus.REJECTED,
+      rejectionReason:
+        "Requester no longer has permission to edit this playlist",
+    });
+  });
+
+  it("rejects add-track requests when the target track has been deleted", async () => {
+    collaboratorRepository.findOne.mockResolvedValue({
+      role: PlaylistCollaboratorRole.EDITOR,
+      status: PlaylistCollaboratorStatus.ACCEPTED,
+    });
+    trackRepository.findOne.mockResolvedValue(null);
+    playlistTrackRepository.findOne.mockResolvedValue(null);
+
+    const result = await validator.validateForApproval(
+      {
+        id: "playlist-1",
+        userId: "owner-1",
+        smartPlaylist: null,
+      } as any,
+      {
+        id: "change-1",
+        playlistId: "playlist-1",
+        requestedById: "editor-1",
+        action: PlaylistChangeAction.ADD_TRACK,
+        payload: { trackId: "track-1" },
+        expiresAt: null,
+      } as any,
+    );
+
+    expect(result).toEqual({
+      isValid: false,
+      status: PlaylistChangeStatus.REJECTED,
+      rejectionReason: "Requested track no longer exists",
+    });
+  });
+
+  it("rejects reorder requests when tracks no longer match the playlist", async () => {
+    collaboratorRepository.findOne.mockResolvedValue({
+      role: PlaylistCollaboratorRole.EDITOR,
+      status: PlaylistCollaboratorStatus.ACCEPTED,
+    });
+    playlistTrackRepository.find.mockResolvedValue([{ trackId: "track-1" }]);
+
+    const result = await validator.validateForApproval(
+      {
+        id: "playlist-1",
+        userId: "owner-1",
+        smartPlaylist: null,
+      } as any,
+      {
+        id: "change-1",
+        playlistId: "playlist-1",
+        requestedById: "editor-1",
+        action: PlaylistChangeAction.REORDER_TRACKS,
+        payload: {
+          tracks: [
+            { trackId: "track-1", position: 0 },
+            { trackId: "track-2", position: 1 },
+          ],
+        },
+        expiresAt: null,
+      } as any,
+    );
+
+    expect(result).toEqual({
+      isValid: false,
+      status: PlaylistChangeStatus.REJECTED,
+      rejectionReason: "One or more tracks are no longer in this playlist",
+    });
+  });
+});

--- a/backend/src/playlists/playlist-change-request.validator.ts
+++ b/backend/src/playlists/playlist-change-request.validator.ts
@@ -1,0 +1,216 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { In, Repository } from "typeorm";
+import { Track } from "../tracks/entities/track.entity";
+import {
+  PlaylistCollaborator,
+  PlaylistCollaboratorRole,
+  PlaylistCollaboratorStatus,
+} from "./entities/playlist-collaborator.entity";
+import {
+  PlaylistChangeAction,
+  PlaylistChangeRequest,
+  PlaylistChangeStatus,
+} from "./entities/playlist-change-request.entity";
+import { Playlist } from "./entities/playlist.entity";
+import { PlaylistTrack } from "./entities/playlist-track.entity";
+
+export interface PlaylistChangeRequestValidationResult {
+  isValid: boolean;
+  rejectionReason?: string;
+  status?: PlaylistChangeStatus;
+}
+
+@Injectable()
+export class PlaylistChangeRequestValidator {
+  constructor(
+    @InjectRepository(PlaylistCollaborator)
+    private readonly collaboratorRepository: Repository<PlaylistCollaborator>,
+    @InjectRepository(PlaylistTrack)
+    private readonly playlistTrackRepository: Repository<PlaylistTrack>,
+    @InjectRepository(Track)
+    private readonly trackRepository: Repository<Track>,
+  ) {}
+
+  async validateForApproval(
+    playlist: Playlist,
+    changeRequest: PlaylistChangeRequest,
+  ): Promise<PlaylistChangeRequestValidationResult> {
+    if (changeRequest.expiresAt && new Date() > changeRequest.expiresAt) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.EXPIRED,
+        rejectionReason: "Change request has expired",
+      };
+    }
+
+    if (playlist.smartPlaylist) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Smart playlists cannot be manually edited",
+      };
+    }
+
+    const requesterRole = await this.getRequesterRole(
+      playlist.id,
+      playlist.userId,
+      changeRequest.requestedById,
+    );
+
+    if (!requesterRole || requesterRole === PlaylistCollaboratorRole.VIEWER) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason:
+          "Requester no longer has permission to edit this playlist",
+      };
+    }
+
+    switch (changeRequest.action) {
+      case PlaylistChangeAction.ADD_TRACK:
+        return this.validateAddTrackRequest(playlist.id, changeRequest);
+      case PlaylistChangeAction.REMOVE_TRACK:
+        return this.validateRemoveTrackRequest(playlist.id, changeRequest);
+      case PlaylistChangeAction.REORDER_TRACKS:
+        return this.validateReorderTracksRequest(playlist.id, changeRequest);
+      default:
+        return {
+          isValid: false,
+          status: PlaylistChangeStatus.REJECTED,
+          rejectionReason: "Unsupported change action",
+        };
+    }
+  }
+
+  private async getRequesterRole(
+    playlistId: string,
+    playlistOwnerId: string,
+    requesterId: string,
+  ): Promise<PlaylistCollaboratorRole | null> {
+    if (playlistOwnerId === requesterId) {
+      return PlaylistCollaboratorRole.OWNER;
+    }
+
+    const collaborator = await this.collaboratorRepository.findOne({
+      where: {
+        playlistId,
+        userId: requesterId,
+        status: PlaylistCollaboratorStatus.ACCEPTED,
+      },
+    });
+
+    return collaborator?.role || null;
+  }
+
+  private async validateAddTrackRequest(
+    playlistId: string,
+    changeRequest: PlaylistChangeRequest,
+  ): Promise<PlaylistChangeRequestValidationResult> {
+    const payload = changeRequest.payload as { trackId?: string };
+
+    if (!payload.trackId) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Track change request is missing a track id",
+      };
+    }
+
+    const [track, existingPlaylistTrack] = await Promise.all([
+      this.trackRepository.findOne({ where: { id: payload.trackId } }),
+      this.playlistTrackRepository.findOne({
+        where: {
+          playlistId,
+          trackId: payload.trackId,
+        },
+      }),
+    ]);
+
+    if (!track) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Requested track no longer exists",
+      };
+    }
+
+    if (existingPlaylistTrack) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Track is already in this playlist",
+      };
+    }
+
+    return { isValid: true };
+  }
+
+  private async validateRemoveTrackRequest(
+    playlistId: string,
+    changeRequest: PlaylistChangeRequest,
+  ): Promise<PlaylistChangeRequestValidationResult> {
+    const payload = changeRequest.payload as { trackId?: string };
+
+    if (!payload.trackId) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Track change request is missing a track id",
+      };
+    }
+
+    const playlistTrack = await this.playlistTrackRepository.findOne({
+      where: {
+        playlistId,
+        trackId: payload.trackId,
+      },
+    });
+
+    if (!playlistTrack) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Track is no longer in this playlist",
+      };
+    }
+
+    return { isValid: true };
+  }
+
+  private async validateReorderTracksRequest(
+    playlistId: string,
+    changeRequest: PlaylistChangeRequest,
+  ): Promise<PlaylistChangeRequestValidationResult> {
+    const payload = changeRequest.payload as {
+      tracks?: { position: number; trackId: string }[];
+    };
+    const requestedTrackIds =
+      payload.tracks?.map((track) => track.trackId) || [];
+
+    if (requestedTrackIds.length === 0) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "Track reorder request is empty",
+      };
+    }
+
+    const existingTracks = await this.playlistTrackRepository.find({
+      where: {
+        playlistId,
+        trackId: In(requestedTrackIds),
+      },
+    });
+
+    if (existingTracks.length !== requestedTrackIds.length) {
+      return {
+        isValid: false,
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason: "One or more tracks are no longer in this playlist",
+      };
+    }
+
+    return { isValid: true };
+  }
+}

--- a/backend/src/playlists/playlists.controller.ts
+++ b/backend/src/playlists/playlists.controller.ts
@@ -11,7 +11,7 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-} from '@nestjs/common';
+} from "@nestjs/common";
 import {
   ApiTags,
   ApiOperation,
@@ -20,32 +20,32 @@ import {
   ApiQuery,
   ApiBearerAuth,
   ApiCookieAuth,
-} from '@nestjs/swagger';
-import { PlaylistsService } from './playlists.service';
-import { SmartPlaylistsService } from './smart-playlists.service';
-import { CreatePlaylistDto } from './dto/create-playlist.dto';
-import { UpdatePlaylistDto } from './dto/update-playlist.dto';
-import { AddTrackDto } from './dto/add-track.dto';
-import { ReorderTracksDto } from './dto/reorder-tracks.dto';
-import { DuplicatePlaylistDto } from './dto/duplicate-playlist.dto';
-import { PlaylistPaginationDto } from './dto/pagination.dto';
-import { InviteCollaboratorDto } from './dto/invite-collaborator.dto';
-import { UpdateCollaboratorRoleDto } from './dto/update-collaborator-role.dto';
-import { CreateSmartPlaylistDto } from './dto/create-smart-playlist.dto';
-import { PreviewSmartPlaylistDto } from './dto/preview-smart-playlist.dto';
-import { ChangeRequestQueryDto } from './dto/change-request-query.dto';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+} from "@nestjs/swagger";
+import { PlaylistsService } from "./playlists.service";
+import { SmartPlaylistsService } from "./smart-playlists.service";
+import { CreatePlaylistDto } from "./dto/create-playlist.dto";
+import { UpdatePlaylistDto } from "./dto/update-playlist.dto";
+import { AddTrackDto } from "./dto/add-track.dto";
+import { ReorderTracksDto } from "./dto/reorder-tracks.dto";
+import { DuplicatePlaylistDto } from "./dto/duplicate-playlist.dto";
+import { PlaylistPaginationDto } from "./dto/pagination.dto";
+import { InviteCollaboratorDto } from "./dto/invite-collaborator.dto";
+import { UpdateCollaboratorRoleDto } from "./dto/update-collaborator-role.dto";
+import { CreateSmartPlaylistDto } from "./dto/create-smart-playlist.dto";
+import { PreviewSmartPlaylistDto } from "./dto/preview-smart-playlist.dto";
+import { ChangeRequestQueryDto } from "./dto/change-request-query.dto";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import {
   CurrentUser,
   CurrentUserData,
-} from '../auth/decorators/current-user.decorator';
-import { Playlist } from './entities/playlist.entity';
-import { PlaylistChangeRequest } from './entities/playlist-change-request.entity';
-import { PlaylistCollaborator } from './entities/playlist-collaborator.entity';
-import { EntityActivityQueryDto } from '../activities/dto/entity-activity-query.dto';
+} from "../auth/decorators/current-user.decorator";
+import { Playlist } from "./entities/playlist.entity";
+import { PlaylistChangeRequest } from "./entities/playlist-change-request.entity";
+import { PlaylistCollaborator } from "./entities/playlist-collaborator.entity";
+import { EntityActivityQueryDto } from "../activities/dto/entity-activity-query.dto";
 
-@ApiTags('Playlists')
-@Controller('playlists')
+@ApiTags("Playlists")
+@Controller("playlists")
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 @ApiCookieAuth()
@@ -57,15 +57,15 @@ export class PlaylistsController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Create a new playlist' })
+  @ApiOperation({ summary: "Create a new playlist" })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description: 'Playlist created successfully',
+    description: "Playlist created successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Invalid input data',
+    description: "Invalid input data",
   })
   async create(
     @CurrentUser() user: CurrentUserData,
@@ -75,13 +75,13 @@ export class PlaylistsController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all playlists for current user' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'isPublic', required: false, type: Boolean })
+  @ApiOperation({ summary: "Get all playlists for current user" })
+  @ApiQuery({ name: "page", required: false, type: Number })
+  @ApiQuery({ name: "limit", required: false, type: Number })
+  @ApiQuery({ name: "isPublic", required: false, type: Boolean })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Playlists retrieved successfully',
+    description: "Playlists retrieved successfully",
   })
   async findAll(
     @CurrentUser() user: CurrentUserData,
@@ -90,11 +90,11 @@ export class PlaylistsController {
     return this.playlistsService.findAll(user.userId, paginationDto);
   }
 
-  @Post('smart/preview')
-  @ApiOperation({ summary: 'Preview tracks for a smart playlist' })
+  @Post("smart/preview")
+  @ApiOperation({ summary: "Preview tracks for a smart playlist" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Smart playlist preview generated',
+    description: "Smart playlist preview generated",
   })
   async previewSmartPlaylist(
     @CurrentUser() user: CurrentUserData,
@@ -106,12 +106,12 @@ export class PlaylistsController {
     );
   }
 
-  @Post('smart')
+  @Post("smart")
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Create a smart playlist' })
+  @ApiOperation({ summary: "Create a smart playlist" })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description: 'Smart playlist created successfully',
+    description: "Smart playlist created successfully",
     type: Playlist,
   })
   async createSmartPlaylist(
@@ -124,68 +124,68 @@ export class PlaylistsController {
     );
   }
 
-  @Get('public')
-  @ApiOperation({ summary: 'Get all public playlists' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @Get("public")
+  @ApiOperation({ summary: "Get all public playlists" })
+  @ApiQuery({ name: "page", required: false, type: Number })
+  @ApiQuery({ name: "limit", required: false, type: Number })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Public playlists retrieved successfully',
+    description: "Public playlists retrieved successfully",
   })
   async findPublic(@Query() paginationDto: PlaylistPaginationDto) {
     return this.playlistsService.findPublic(paginationDto);
   }
 
-  @Get('user/:userId')
+  @Get("user/:userId")
   @ApiOperation({ summary: "Get playlists by user ID" })
-  @ApiParam({ name: 'userId', description: 'User ID' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'isPublic', required: false, type: Boolean })
+  @ApiParam({ name: "userId", description: "User ID" })
+  @ApiQuery({ name: "page", required: false, type: Number })
+  @ApiQuery({ name: "limit", required: false, type: Number })
+  @ApiQuery({ name: "isPublic", required: false, type: Boolean })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'User playlists retrieved successfully',
+    description: "User playlists retrieved successfully",
   })
   async findByUser(
-    @Param('userId', ParseUUIDPipe) userId: string,
+    @Param("userId", ParseUUIDPipe) userId: string,
     @CurrentUser() user: CurrentUserData,
     @Query() paginationDto: PlaylistPaginationDto,
   ) {
     return this.playlistsService.findByUser(userId, user.userId, paginationDto);
   }
 
-  @Get(':id')
-  @ApiOperation({ summary: 'Get a playlist by ID with tracks' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Get(":id")
+  @ApiOperation({ summary: "Get a playlist by ID with tracks" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Playlist found',
+    description: "Playlist found",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist not found',
+    description: "Playlist not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async findOne(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<Playlist> {
     return this.playlistsService.findOne(id, user.userId);
   }
 
-  @Get(':id/activities')
-  @ApiOperation({ summary: 'Get playlist activity log' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Get(":id/activities")
+  @ApiOperation({ summary: "Get playlist activity log" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Playlist activities retrieved successfully',
+    description: "Playlist activities retrieved successfully",
   })
   async getPlaylistActivities(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Query() query: EntityActivityQueryDto,
   ) {
@@ -196,202 +196,210 @@ export class PlaylistsController {
     );
   }
 
-  @Patch(':id')
-  @ApiOperation({ summary: 'Update a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Patch(":id")
+  @ApiOperation({ summary: "Update a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Playlist updated successfully',
+    description: "Playlist updated successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist not found',
+    description: "Playlist not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
     @Body() updatePlaylistDto: UpdatePlaylistDto,
   ): Promise<Playlist> {
     return this.playlistsService.update(id, user.userId, updatePlaylistDto);
   }
 
-  @Delete(':id')
+  @Delete(":id")
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Delete a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @ApiOperation({ summary: "Delete a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
-    description: 'Playlist deleted successfully',
+    description: "Playlist deleted successfully",
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist not found',
+    description: "Playlist not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async remove(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<void> {
     return this.playlistsService.remove(id, user.userId);
   }
 
-  @Post(':id/tracks')
-  @ApiOperation({ summary: 'Add a track to a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Post(":id/tracks")
+  @ApiOperation({ summary: "Add a track to a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Track added successfully',
+    description: "Track added successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Track already in playlist or invalid data',
+    description: "Track already in playlist or invalid data",
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist or track not found',
+    description: "Playlist or track not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async addTrack(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Body() addTrackDto: AddTrackDto,
   ): Promise<Playlist | PlaylistChangeRequest> {
     return this.playlistsService.addTrack(playlistId, user.userId, addTrackDto);
   }
 
-  @Delete(':id/tracks/:trackId')
+  @Delete(":id/tracks/:trackId")
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Remove a track from a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'trackId', description: 'Track ID' })
+  @ApiOperation({ summary: "Remove a track from a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "trackId", description: "Track ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Track removed successfully',
+    description: "Track removed successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist or track not found',
+    description: "Playlist or track not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async removeTrack(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('trackId', ParseUUIDPipe) trackId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("trackId", ParseUUIDPipe) trackId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<Playlist | PlaylistChangeRequest> {
     return this.playlistsService.removeTrack(playlistId, trackId, user.userId);
   }
 
-  @Patch(':id/tracks/reorder')
-  @ApiOperation({ summary: 'Reorder tracks in a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Patch(":id/tracks/reorder")
+  @ApiOperation({ summary: "Reorder tracks in a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Tracks reordered successfully',
+    description: "Tracks reordered successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
-    description: 'Invalid track positions',
+    description: "Invalid track positions",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async reorderTracks(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Body() reorderTracksDto: ReorderTracksDto,
   ): Promise<Playlist | PlaylistChangeRequest> {
-    return this.playlistsService.reorderTracks(playlistId, user.userId, reorderTracksDto);
+    return this.playlistsService.reorderTracks(
+      playlistId,
+      user.userId,
+      reorderTracksDto,
+    );
   }
 
-  @Post(':id/duplicate')
-  @ApiOperation({ summary: 'Duplicate a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID to duplicate' })
+  @Post(":id/duplicate")
+  @ApiOperation({ summary: "Duplicate a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID to duplicate" })
   @ApiResponse({
     status: HttpStatus.CREATED,
-    description: 'Playlist duplicated successfully',
+    description: "Playlist duplicated successfully",
     type: Playlist,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist not found',
+    description: "Playlist not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async duplicate(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Body() duplicateDto?: DuplicatePlaylistDto,
   ): Promise<Playlist> {
-    return this.playlistsService.duplicate(playlistId, user.userId, duplicateDto);
+    return this.playlistsService.duplicate(
+      playlistId,
+      user.userId,
+      duplicateDto,
+    );
   }
 
-  @Post(':id/share')
-  @ApiOperation({ summary: 'Share a playlist (makes it public)' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Post(":id/share")
+  @ApiOperation({ summary: "Share a playlist (makes it public)" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Playlist shared successfully',
+    description: "Playlist shared successfully",
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Playlist not found',
+    description: "Playlist not found",
   })
   @ApiResponse({
     status: HttpStatus.FORBIDDEN,
-    description: 'Access denied',
+    description: "Access denied",
   })
   async share(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
   ) {
     return this.playlistsService.share(playlistId, user.userId);
   }
 
-  @Get(':id/collaborators')
-  @ApiOperation({ summary: 'List playlist collaborators' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Get(":id/collaborators")
+  @ApiOperation({ summary: "List playlist collaborators" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Collaborators retrieved successfully',
+    description: "Collaborators retrieved successfully",
     type: [PlaylistCollaborator],
   })
   async listCollaborators(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PlaylistCollaborator[]> {
     return this.playlistsService.listCollaborators(playlistId, user.userId);
   }
 
-  @Post(':id/collaborators')
-  @ApiOperation({ summary: 'Invite a collaborator to a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Post(":id/collaborators")
+  @ApiOperation({ summary: "Invite a collaborator to a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Collaborator invited successfully',
+    description: "Collaborator invited successfully",
     type: PlaylistCollaborator,
   })
   async inviteCollaborator(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Body() inviteDto: InviteCollaboratorDto,
   ): Promise<PlaylistCollaborator> {
@@ -403,18 +411,18 @@ export class PlaylistsController {
     );
   }
 
-  @Post(':id/collaborators/:collaboratorId/accept')
-  @ApiOperation({ summary: 'Accept a collaborator invite' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'collaboratorId', description: 'Collaborator ID' })
+  @Post(":id/collaborators/:collaboratorId/accept")
+  @ApiOperation({ summary: "Accept a collaborator invite" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "collaboratorId", description: "Collaborator ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Collaborator invite accepted',
+    description: "Collaborator invite accepted",
     type: PlaylistCollaborator,
   })
   async acceptCollaboratorInvite(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('collaboratorId', ParseUUIDPipe) collaboratorId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("collaboratorId", ParseUUIDPipe) collaboratorId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<PlaylistCollaborator> {
     return this.playlistsService.acceptCollaboratorInvite(
@@ -424,18 +432,18 @@ export class PlaylistsController {
     );
   }
 
-  @Post(':id/collaborators/:collaboratorId/reject')
-  @ApiOperation({ summary: 'Reject a collaborator invite' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'collaboratorId', description: 'Collaborator ID' })
+  @Post(":id/collaborators/:collaboratorId/reject")
+  @ApiOperation({ summary: "Reject a collaborator invite" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "collaboratorId", description: "Collaborator ID" })
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
-    description: 'Collaborator invite rejected',
+    description: "Collaborator invite rejected",
   })
   @HttpCode(HttpStatus.NO_CONTENT)
   async rejectCollaboratorInvite(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('collaboratorId', ParseUUIDPipe) collaboratorId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("collaboratorId", ParseUUIDPipe) collaboratorId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<void> {
     return this.playlistsService.rejectCollaboratorInvite(
@@ -445,18 +453,18 @@ export class PlaylistsController {
     );
   }
 
-  @Patch(':id/collaborators/:collaboratorId')
-  @ApiOperation({ summary: 'Update collaborator role' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'collaboratorId', description: 'Collaborator ID' })
+  @Patch(":id/collaborators/:collaboratorId")
+  @ApiOperation({ summary: "Update collaborator role" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "collaboratorId", description: "Collaborator ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Collaborator role updated',
+    description: "Collaborator role updated",
     type: PlaylistCollaborator,
   })
   async updateCollaboratorRole(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('collaboratorId', ParseUUIDPipe) collaboratorId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("collaboratorId", ParseUUIDPipe) collaboratorId: string,
     @CurrentUser() user: CurrentUserData,
     @Body() updateDto: UpdateCollaboratorRoleDto,
   ): Promise<PlaylistCollaborator> {
@@ -468,18 +476,18 @@ export class PlaylistsController {
     );
   }
 
-  @Delete(':id/collaborators/:collaboratorId')
+  @Delete(":id/collaborators/:collaboratorId")
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remove a collaborator from a playlist' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'collaboratorId', description: 'Collaborator ID' })
+  @ApiOperation({ summary: "Remove a collaborator from a playlist" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "collaboratorId", description: "Collaborator ID" })
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
-    description: 'Collaborator removed successfully',
+    description: "Collaborator removed successfully",
   })
   async removeCollaborator(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('collaboratorId', ParseUUIDPipe) collaboratorId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("collaboratorId", ParseUUIDPipe) collaboratorId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<void> {
     return this.playlistsService.removeCollaborator(
@@ -489,16 +497,16 @@ export class PlaylistsController {
     );
   }
 
-  @Get(':id/change-requests')
-  @ApiOperation({ summary: 'List playlist change requests' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
+  @Get(":id/change-requests")
+  @ApiOperation({ summary: "List playlist change requests" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Change requests retrieved successfully',
+    description: "Change requests retrieved successfully",
     type: [PlaylistChangeRequest],
   })
   async listChangeRequests(
-    @Param('id', ParseUUIDPipe) playlistId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
     @CurrentUser() user: CurrentUserData,
     @Query() query: ChangeRequestQueryDto,
   ): Promise<PlaylistChangeRequest[]> {
@@ -509,18 +517,22 @@ export class PlaylistsController {
     );
   }
 
-  @Post(':id/change-requests/:changeRequestId/approve')
-  @ApiOperation({ summary: 'Approve a playlist change request' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'changeRequestId', description: 'Change request ID' })
+  @Post(":id/change-requests/:changeRequestId/approve")
+  @ApiOperation({ summary: "Approve a playlist change request" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "changeRequestId", description: "Change request ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Change request approved and applied',
+    description: "Change request approved and applied",
     type: Playlist,
   })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: "Change request is stale, expired, or already reviewed",
+  })
   async approveChangeRequest(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('changeRequestId', ParseUUIDPipe) changeRequestId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("changeRequestId", ParseUUIDPipe) changeRequestId: string,
     @CurrentUser() user: CurrentUserData,
   ): Promise<Playlist> {
     return this.playlistsService.approveChangeRequest(
@@ -530,24 +542,30 @@ export class PlaylistsController {
     );
   }
 
-  @Post(':id/change-requests/:changeRequestId/reject')
-  @ApiOperation({ summary: 'Reject a playlist change request' })
-  @ApiParam({ name: 'id', description: 'Playlist ID' })
-  @ApiParam({ name: 'changeRequestId', description: 'Change request ID' })
+  @Post(":id/change-requests/:changeRequestId/reject")
+  @ApiOperation({ summary: "Reject a playlist change request" })
+  @ApiParam({ name: "id", description: "Playlist ID" })
+  @ApiParam({ name: "changeRequestId", description: "Change request ID" })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Change request rejected',
+    description: "Change request rejected",
     type: PlaylistChangeRequest,
   })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: "Change request is expired or already reviewed",
+  })
   async rejectChangeRequest(
-    @Param('id', ParseUUIDPipe) playlistId: string,
-    @Param('changeRequestId', ParseUUIDPipe) changeRequestId: string,
+    @Param("id", ParseUUIDPipe) playlistId: string,
+    @Param("changeRequestId", ParseUUIDPipe) changeRequestId: string,
     @CurrentUser() user: CurrentUserData,
+    @Body("reason") reason?: string,
   ): Promise<PlaylistChangeRequest> {
     return this.playlistsService.rejectChangeRequest(
       playlistId,
       changeRequestId,
       user.userId,
+      reason,
     );
   }
 }

--- a/backend/src/playlists/playlists.module.ts
+++ b/backend/src/playlists/playlists.module.ts
@@ -1,18 +1,19 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { PlaylistsService } from './playlists.service';
-import { PlaylistsController } from './playlists.controller';
-import { Playlist } from './entities/playlist.entity';
-import { PlaylistTrack } from './entities/playlist-track.entity';
-import { PlaylistCollaborator } from './entities/playlist-collaborator.entity';
-import { SmartPlaylist } from './entities/smart-playlist.entity';
-import { PlaylistChangeRequest } from './entities/playlist-change-request.entity';
-import { Track } from '../tracks/entities/track.entity';
-import { ActivitiesModule } from '../activities/activities.module';
-import { UsersModule } from '../users/users.module';
-import { SmartPlaylistsService } from './smart-playlists.service';
-import { SmartPlaylistsScheduler } from './smart-playlists.scheduler';
-import { Follow } from '../follows/entities/follow.entity';
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { PlaylistsService } from "./playlists.service";
+import { PlaylistsController } from "./playlists.controller";
+import { Playlist } from "./entities/playlist.entity";
+import { PlaylistTrack } from "./entities/playlist-track.entity";
+import { PlaylistCollaborator } from "./entities/playlist-collaborator.entity";
+import { SmartPlaylist } from "./entities/smart-playlist.entity";
+import { PlaylistChangeRequest } from "./entities/playlist-change-request.entity";
+import { Track } from "../tracks/entities/track.entity";
+import { ActivitiesModule } from "../activities/activities.module";
+import { UsersModule } from "../users/users.module";
+import { SmartPlaylistsService } from "./smart-playlists.service";
+import { SmartPlaylistsScheduler } from "./smart-playlists.scheduler";
+import { Follow } from "../follows/entities/follow.entity";
+import { PlaylistChangeRequestValidator } from "./playlist-change-request.validator";
 
 @Module({
   imports: [
@@ -29,7 +30,12 @@ import { Follow } from '../follows/entities/follow.entity';
     UsersModule,
   ],
   controllers: [PlaylistsController],
-  providers: [PlaylistsService, SmartPlaylistsService, SmartPlaylistsScheduler],
+  providers: [
+    PlaylistsService,
+    SmartPlaylistsService,
+    SmartPlaylistsScheduler,
+    PlaylistChangeRequestValidator,
+  ],
   exports: [PlaylistsService, SmartPlaylistsService],
 })
 export class PlaylistsModule {}

--- a/backend/src/playlists/playlists.service.spec.ts
+++ b/backend/src/playlists/playlists.service.spec.ts
@@ -1,26 +1,27 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { ForbiddenException } from '@nestjs/common';
-import { PlaylistsService } from './playlists.service';
-import { Playlist } from './entities/playlist.entity';
-import { PlaylistTrack } from './entities/playlist-track.entity';
-import { Track } from '../tracks/entities/track.entity';
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import { PlaylistsService } from "./playlists.service";
+import { Playlist } from "./entities/playlist.entity";
+import { PlaylistTrack } from "./entities/playlist-track.entity";
+import { Track } from "../tracks/entities/track.entity";
 import {
   PlaylistCollaborator,
   PlaylistCollaboratorRole,
   PlaylistCollaboratorStatus,
-} from './entities/playlist-collaborator.entity';
+} from "./entities/playlist-collaborator.entity";
 import {
   PlaylistChangeAction,
   PlaylistChangeRequest,
   PlaylistChangeStatus,
-} from './entities/playlist-change-request.entity';
-import { SmartPlaylist } from './entities/smart-playlist.entity';
-import { ActivitiesService } from '../activities/activities.service';
-import { UsersService } from '../users/users.service';
-import { ActivityType } from '../activities/entities/activity.entity';
+} from "./entities/playlist-change-request.entity";
+import { SmartPlaylist } from "./entities/smart-playlist.entity";
+import { ActivitiesService } from "../activities/activities.service";
+import { UsersService } from "../users/users.service";
+import { ActivityType } from "../activities/entities/activity.entity";
+import { PlaylistChangeRequestValidator } from "./playlist-change-request.validator";
 
-describe('PlaylistsService', () => {
+describe("PlaylistsService", () => {
   let service: PlaylistsService;
   let activitiesService: ActivitiesService;
 
@@ -69,6 +70,10 @@ describe('PlaylistsService', () => {
     findByEmail: jest.fn(),
   };
 
+  const mockChangeRequestValidator = {
+    validateForApproval: jest.fn().mockResolvedValue({ isValid: true }),
+  };
+
   const mockQueryBuilder = {
     update: jest.fn().mockReturnThis(),
     set: jest.fn().mockReturnThis(),
@@ -80,7 +85,9 @@ describe('PlaylistsService', () => {
   };
 
   beforeEach(async () => {
-    playlistTrackRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    playlistTrackRepository.createQueryBuilder.mockReturnValue(
+      mockQueryBuilder,
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -117,6 +124,10 @@ describe('PlaylistsService', () => {
           provide: UsersService,
           useValue: mockUsersService,
         },
+        {
+          provide: PlaylistChangeRequestValidator,
+          useValue: mockChangeRequestValidator,
+        },
       ],
     }).compile();
 
@@ -128,10 +139,10 @@ describe('PlaylistsService', () => {
     jest.clearAllMocks();
   });
 
-  it('creates a change request when approval is required for an editor', async () => {
+  it("creates a change request when approval is required for an editor", async () => {
     const playlist = {
-      id: 'playlist-1',
-      userId: 'owner-1',
+      id: "playlist-1",
+      userId: "owner-1",
       approvalRequired: true,
       smartPlaylist: null,
     } as Playlist;
@@ -142,36 +153,41 @@ describe('PlaylistsService', () => {
       status: PlaylistCollaboratorStatus.ACCEPTED,
     });
     trackRepository.findOne.mockResolvedValue({
-      id: 'track-1',
-      title: 'Track 1',
+      id: "track-1",
+      title: "Track 1",
     });
     playlistTrackRepository.findOne.mockResolvedValue(null);
 
     const changeRequest = {
-      id: 'change-1',
-      playlistId: 'playlist-1',
-      requestedById: 'editor-1',
+      id: "change-1",
+      playlistId: "playlist-1",
+      requestedById: "editor-1",
       action: PlaylistChangeAction.ADD_TRACK,
       status: PlaylistChangeStatus.PENDING,
-      payload: { trackId: 'track-1' },
-    } as PlaylistChangeRequest;
+      payload: { trackId: "track-1" },
+    } as unknown as PlaylistChangeRequest;
 
     changeRequestRepository.create.mockReturnValue(changeRequest);
     changeRequestRepository.save.mockResolvedValue(changeRequest);
 
-    const result = await service.addTrack('playlist-1', 'editor-1', {
-      trackId: 'track-1',
+    const result = await service.addTrack("playlist-1", "editor-1", {
+      trackId: "track-1",
     });
 
     expect(result).toEqual(changeRequest);
     expect(changeRequestRepository.save).toHaveBeenCalled();
     expect(playlistTrackRepository.save).not.toHaveBeenCalled();
+    expect(changeRequestRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expiresAt: expect.any(Date),
+      }),
+    );
   });
 
-  it('prevents viewers from adding tracks', async () => {
+  it("prevents viewers from adding tracks", async () => {
     const playlist = {
-      id: 'playlist-1',
-      userId: 'owner-1',
+      id: "playlist-1",
+      userId: "owner-1",
       approvalRequired: false,
       smartPlaylist: null,
     } as Playlist;
@@ -183,16 +199,16 @@ describe('PlaylistsService', () => {
     });
 
     await expect(
-      service.addTrack('playlist-1', 'viewer-1', {
-        trackId: 'track-1',
+      service.addTrack("playlist-1", "viewer-1", {
+        trackId: "track-1",
       }),
     ).rejects.toThrow(ForbiddenException);
   });
 
-  it('logs activity when a track is added directly', async () => {
+  it("logs activity when a track is added directly", async () => {
     const playlist = {
-      id: 'playlist-1',
-      userId: 'owner-1',
+      id: "playlist-1",
+      userId: "owner-1",
       approvalRequired: false,
       trackCount: 0,
       totalDuration: 0,
@@ -201,19 +217,19 @@ describe('PlaylistsService', () => {
 
     playlistRepository.findOne.mockResolvedValue(playlist);
     trackRepository.findOne.mockResolvedValue({
-      id: 'track-1',
-      title: 'Track 1',
+      id: "track-1",
+      title: "Track 1",
       duration: 120,
     });
     playlistTrackRepository.findOne.mockResolvedValue(null);
     playlistTrackRepository.create.mockReturnValue({
       playlistId: playlist.id,
-      trackId: 'track-1',
+      trackId: "track-1",
     });
     playlistTrackRepository.save.mockResolvedValue({});
     playlistRepository.save.mockResolvedValue(playlist);
 
-    await service.addTrack('playlist-1', 'owner-1', { trackId: 'track-1' });
+    await service.addTrack("playlist-1", "owner-1", { trackId: "track-1" });
 
     expect(activitiesService.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -222,36 +238,36 @@ describe('PlaylistsService', () => {
     );
   });
 
-  it('invites collaborators as owner', async () => {
+  it("invites collaborators as owner", async () => {
     const playlist = {
-      id: 'playlist-1',
-      userId: 'owner-1',
+      id: "playlist-1",
+      userId: "owner-1",
       smartPlaylist: null,
     } as Playlist;
 
     playlistRepository.findOne.mockResolvedValue(playlist);
     mockUsersService.findByUsername.mockResolvedValue({
-      id: 'user-2',
+      id: "user-2",
     });
     collaboratorRepository.findOne.mockResolvedValue(null);
     collaboratorRepository.create.mockReturnValue({
-      playlistId: 'playlist-1',
-      userId: 'user-2',
+      playlistId: "playlist-1",
+      userId: "user-2",
       role: PlaylistCollaboratorRole.EDITOR,
       status: PlaylistCollaboratorStatus.PENDING,
     });
     collaboratorRepository.save.mockResolvedValue({
-      id: 'collab-1',
-      playlistId: 'playlist-1',
-      userId: 'user-2',
+      id: "collab-1",
+      playlistId: "playlist-1",
+      userId: "user-2",
       role: PlaylistCollaboratorRole.EDITOR,
       status: PlaylistCollaboratorStatus.PENDING,
     });
 
     const result = await service.inviteCollaborator(
-      'playlist-1',
-      'owner-1',
-      'user2',
+      "playlist-1",
+      "owner-1",
+      "user2",
       PlaylistCollaboratorRole.EDITOR,
     );
 
@@ -259,50 +275,147 @@ describe('PlaylistsService', () => {
     expect(activitiesService.create).toHaveBeenCalled();
   });
 
-  it('accepts collaborator invites', async () => {
+  it("accepts collaborator invites", async () => {
     collaboratorRepository.findOne.mockResolvedValue({
-      id: 'collab-1',
-      playlistId: 'playlist-1',
-      userId: 'user-2',
+      id: "collab-1",
+      playlistId: "playlist-1",
+      userId: "user-2",
       role: PlaylistCollaboratorRole.EDITOR,
       status: PlaylistCollaboratorStatus.PENDING,
     });
     collaboratorRepository.save.mockResolvedValue({
-      id: 'collab-1',
-      playlistId: 'playlist-1',
-      userId: 'user-2',
+      id: "collab-1",
+      playlistId: "playlist-1",
+      userId: "user-2",
       role: PlaylistCollaboratorRole.EDITOR,
       status: PlaylistCollaboratorStatus.ACCEPTED,
     });
 
     const result = await service.acceptCollaboratorInvite(
-      'playlist-1',
-      'collab-1',
-      'user-2',
+      "playlist-1",
+      "collab-1",
+      "user-2",
     );
 
     expect(result.status).toBe(PlaylistCollaboratorStatus.ACCEPTED);
     expect(activitiesService.create).toHaveBeenCalled();
   });
 
-  it('removes collaborators as owner', async () => {
+  it("removes collaborators as owner", async () => {
     const playlist = {
-      id: 'playlist-1',
-      userId: 'owner-1',
+      id: "playlist-1",
+      userId: "owner-1",
       smartPlaylist: null,
     } as Playlist;
 
     playlistRepository.findOne.mockResolvedValue(playlist);
     collaboratorRepository.findOne.mockResolvedValue({
-      id: 'collab-1',
-      playlistId: 'playlist-1',
-      userId: 'user-2',
+      id: "collab-1",
+      playlistId: "playlist-1",
+      userId: "user-2",
       role: PlaylistCollaboratorRole.EDITOR,
     });
 
-    await service.removeCollaborator('playlist-1', 'collab-1', 'owner-1');
+    await service.removeCollaborator("playlist-1", "collab-1", "owner-1");
 
     expect(collaboratorRepository.remove).toHaveBeenCalled();
     expect(activitiesService.create).toHaveBeenCalled();
+  });
+
+  it("expires stale change requests during approval", async () => {
+    playlistRepository.findOne.mockResolvedValue({
+      id: "playlist-1",
+      userId: "owner-1",
+      approvalRequired: true,
+      smartPlaylist: null,
+    });
+    changeRequestRepository.findOne.mockResolvedValue({
+      id: "change-1",
+      playlistId: "playlist-1",
+      requestedById: "editor-1",
+      action: PlaylistChangeAction.ADD_TRACK,
+      status: PlaylistChangeStatus.PENDING,
+      payload: { trackId: "track-1" },
+    });
+    mockChangeRequestValidator.validateForApproval.mockResolvedValue({
+      isValid: false,
+      status: PlaylistChangeStatus.EXPIRED,
+      rejectionReason: "Change request has expired",
+    });
+
+    await expect(
+      service.approveChangeRequest("playlist-1", "change-1", "owner-1"),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(changeRequestRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "change-1",
+        status: PlaylistChangeStatus.EXPIRED,
+        rejectionReason: "Change request has expired",
+      }),
+    );
+  });
+
+  it("rejects change requests that are no longer valid at approval time", async () => {
+    playlistRepository.findOne.mockResolvedValue({
+      id: "playlist-1",
+      userId: "owner-1",
+      approvalRequired: true,
+      smartPlaylist: null,
+    });
+    changeRequestRepository.findOne.mockResolvedValue({
+      id: "change-1",
+      playlistId: "playlist-1",
+      requestedById: "editor-1",
+      action: PlaylistChangeAction.ADD_TRACK,
+      status: PlaylistChangeStatus.PENDING,
+      payload: { trackId: "track-1" },
+    });
+    mockChangeRequestValidator.validateForApproval.mockResolvedValue({
+      isValid: false,
+      status: PlaylistChangeStatus.REJECTED,
+      rejectionReason:
+        "Requester no longer has permission to edit this playlist",
+    });
+
+    await expect(
+      service.approveChangeRequest("playlist-1", "change-1", "owner-1"),
+    ).rejects.toThrow(
+      "Requester no longer has permission to edit this playlist",
+    );
+
+    expect(changeRequestRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: PlaylistChangeStatus.REJECTED,
+        rejectionReason:
+          "Requester no longer has permission to edit this playlist",
+      }),
+    );
+  });
+
+  it("rejects duplicate approvals without replaying the change", async () => {
+    playlistRepository.findOne.mockResolvedValue({
+      id: "playlist-1",
+      userId: "owner-1",
+      approvalRequired: true,
+      smartPlaylist: null,
+    });
+    changeRequestRepository.findOne.mockResolvedValue({
+      id: "change-1",
+      playlistId: "playlist-1",
+      requestedById: "editor-1",
+      action: PlaylistChangeAction.ADD_TRACK,
+      status: PlaylistChangeStatus.APPROVED,
+      payload: { trackId: "track-1" },
+    });
+
+    await expect(
+      service.approveChangeRequest("playlist-1", "change-1", "owner-1"),
+    ).rejects.toThrow("Change request is already approved");
+
+    expect(
+      mockChangeRequestValidator.validateForApproval,
+    ).not.toHaveBeenCalled();
+    expect(playlistTrackRepository.save).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/playlists/playlists.service.ts
+++ b/backend/src/playlists/playlists.service.ts
@@ -38,9 +38,14 @@ import {
   PlaylistPaginationDto,
 } from "./dto/pagination.dto";
 import { DuplicatePlaylistDto } from "./dto/duplicate-playlist.dto";
+import {
+  PlaylistChangeRequestValidationResult,
+  PlaylistChangeRequestValidator,
+} from "./playlist-change-request.validator";
 
 @Injectable()
 export class PlaylistsService {
+  private static readonly CHANGE_REQUEST_TTL_MS = 7 * 24 * 60 * 60 * 1000;
   private readonly logger = new Logger(PlaylistsService.name);
 
   constructor(
@@ -58,6 +63,7 @@ export class PlaylistsService {
     private readonly trackRepository: Repository<Track>,
     private readonly activitiesService: ActivitiesService,
     private readonly usersService: UsersService,
+    private readonly changeRequestValidator: PlaylistChangeRequestValidator,
   ) {}
 
   /**
@@ -730,7 +736,6 @@ export class PlaylistsService {
       where: {
         id: changeRequestId,
         playlistId,
-        status: PlaylistChangeStatus.PENDING,
       },
     });
 
@@ -738,48 +743,78 @@ export class PlaylistsService {
       throw new NotFoundException("Change request not found");
     }
 
-    // Check if change request has expired
-    if (changeRequest.expiresAt && new Date() > changeRequest.expiresAt) {
-      changeRequest.status = PlaylistChangeStatus.EXPIRED;
-      await this.changeRequestRepository.save(changeRequest);
-      throw new BadRequestException("Change request has expired");
+    if (changeRequest.status !== PlaylistChangeStatus.PENDING) {
+      throw new BadRequestException(
+        `Change request is already ${changeRequest.status}`,
+      );
+    }
+
+    const validationResult =
+      await this.changeRequestValidator.validateForApproval(
+        playlist,
+        changeRequest,
+      );
+    if (!validationResult.isValid) {
+      await this.rejectInvalidChangeRequest(
+        changeRequest,
+        userId,
+        validationResult,
+      );
     }
 
     let updatedPlaylist: Playlist;
 
-    if (changeRequest.action === PlaylistChangeAction.ADD_TRACK) {
-      const payload = changeRequest.payload as {
-        trackId: string;
-        position?: number;
-      };
-      updatedPlaylist = await this.applyAddTrack(
-        playlist,
-        changeRequest.requestedById,
-        payload,
-        userId,
-      );
-    } else if (changeRequest.action === PlaylistChangeAction.REMOVE_TRACK) {
-      const payload = changeRequest.payload as { trackId: string };
-      updatedPlaylist = await this.applyRemoveTrack(
-        playlistId,
-        payload.trackId,
-        changeRequest.requestedById,
-        userId,
-      );
-    } else if (changeRequest.action === PlaylistChangeAction.REORDER_TRACKS) {
-      const payload = changeRequest.payload as {
-        tracks: { trackId: string; position: number }[];
-      };
-      await this.applyReorderTracks(playlistId, { tracks: payload.tracks });
-      updatedPlaylist = await this.findOne(playlistId, userId);
-    } else {
-      throw new BadRequestException("Unsupported change action");
+    try {
+      if (changeRequest.action === PlaylistChangeAction.ADD_TRACK) {
+        const payload = changeRequest.payload as {
+          trackId: string;
+          position?: number;
+        };
+        updatedPlaylist = await this.applyAddTrack(
+          playlist,
+          changeRequest.requestedById,
+          payload,
+          userId,
+        );
+      } else if (changeRequest.action === PlaylistChangeAction.REMOVE_TRACK) {
+        const payload = changeRequest.payload as { trackId: string };
+        updatedPlaylist = await this.applyRemoveTrack(
+          playlistId,
+          payload.trackId,
+          changeRequest.requestedById,
+          userId,
+        );
+      } else if (changeRequest.action === PlaylistChangeAction.REORDER_TRACKS) {
+        const payload = changeRequest.payload as {
+          tracks: { trackId: string; position: number }[];
+        };
+        await this.applyReorderTracks(playlistId, { tracks: payload.tracks });
+        updatedPlaylist = await this.findOne(playlistId, userId);
+      } else {
+        throw new BadRequestException("Unsupported change action");
+      }
+    } catch (error) {
+      if (
+        error instanceof BadRequestException ||
+        error instanceof NotFoundException ||
+        error instanceof ForbiddenException
+      ) {
+        await this.rejectInvalidChangeRequest(changeRequest, userId, {
+          isValid: false,
+          status: PlaylistChangeStatus.REJECTED,
+          rejectionReason: this.extractExceptionMessage(
+            error,
+            "Change request is no longer valid",
+          ),
+        });
+      }
+
+      throw error;
     }
 
     changeRequest.status = PlaylistChangeStatus.APPROVED;
     changeRequest.reviewedById = userId;
     changeRequest.reviewedAt = new Date();
-    changeRequest.updatedAt = new Date();
     await this.changeRequestRepository.save(changeRequest);
 
     await this.safeCreateActivity({
@@ -817,7 +852,6 @@ export class PlaylistsService {
       where: {
         id: changeRequestId,
         playlistId,
-        status: PlaylistChangeStatus.PENDING,
       },
     });
 
@@ -825,9 +859,16 @@ export class PlaylistsService {
       throw new NotFoundException("Change request not found");
     }
 
-    // Check if change request has expired
+    if (changeRequest.status !== PlaylistChangeStatus.PENDING) {
+      throw new BadRequestException(
+        `Change request is already ${changeRequest.status}`,
+      );
+    }
+
     if (changeRequest.expiresAt && new Date() > changeRequest.expiresAt) {
       changeRequest.status = PlaylistChangeStatus.EXPIRED;
+      changeRequest.reviewedById = userId;
+      changeRequest.reviewedAt = new Date();
       await this.changeRequestRepository.save(changeRequest);
       throw new BadRequestException("Change request has expired");
     }
@@ -836,7 +877,6 @@ export class PlaylistsService {
     changeRequest.reviewedById = userId;
     changeRequest.reviewedAt = new Date();
     changeRequest.rejectionReason = reason || null;
-    changeRequest.updatedAt = new Date();
 
     const saved = await this.changeRequestRepository.save(changeRequest);
 
@@ -865,12 +905,17 @@ export class PlaylistsService {
       where: {
         id: changeRequestId,
         playlistId,
-        status: PlaylistChangeStatus.PENDING,
       },
     });
 
     if (!changeRequest) {
       throw new NotFoundException("Change request not found");
+    }
+
+    if (changeRequest.status !== PlaylistChangeStatus.PENDING) {
+      throw new BadRequestException(
+        `Change request is already ${changeRequest.status}`,
+      );
     }
 
     // Only the requester or playlist owner can cancel
@@ -883,7 +928,6 @@ export class PlaylistsService {
 
     changeRequest.status = PlaylistChangeStatus.CANCELLED;
     changeRequest.cancelledAt = new Date();
-    changeRequest.updatedAt = new Date();
 
     const saved = await this.changeRequestRepository.save(changeRequest);
 
@@ -919,7 +963,6 @@ export class PlaylistsService {
 
     for (const request of expiredRequests) {
       request.status = PlaylistChangeStatus.EXPIRED;
-      request.updatedAt = new Date();
       await this.changeRequestRepository.save(request);
 
       await this.safeCreateActivity({
@@ -934,7 +977,9 @@ export class PlaylistsService {
       });
     }
 
-    this.logger.log(`Cleaned up ${expiredRequests.length} expired change requests`);
+    this.logger.log(
+      `Cleaned up ${expiredRequests.length} expired change requests`,
+    );
     return expiredRequests.length;
   }
 
@@ -1062,6 +1107,7 @@ export class PlaylistsService {
       action,
       payload,
       status: PlaylistChangeStatus.PENDING,
+      expiresAt: new Date(Date.now() + PlaylistsService.CHANGE_REQUEST_TTL_MS),
     });
 
     const saved = await this.changeRequestRepository.save(changeRequest);
@@ -1079,6 +1125,68 @@ export class PlaylistsService {
     });
 
     return saved;
+  }
+
+  private async rejectInvalidChangeRequest(
+    changeRequest: PlaylistChangeRequest,
+    reviewerUserId: string,
+    validationResult: PlaylistChangeRequestValidationResult,
+  ): Promise<never> {
+    changeRequest.status =
+      validationResult.status || PlaylistChangeStatus.REJECTED;
+    changeRequest.reviewedById = reviewerUserId;
+    changeRequest.reviewedAt = new Date();
+    changeRequest.rejectionReason =
+      validationResult.rejectionReason || "Change request is no longer valid";
+
+    await this.changeRequestRepository.save(changeRequest);
+
+    await this.safeCreateActivity({
+      userId: reviewerUserId,
+      activityType:
+        changeRequest.status === PlaylistChangeStatus.EXPIRED
+          ? ActivityType.PLAYLIST_CHANGE_EXPIRED
+          : ActivityType.PLAYLIST_CHANGE_REJECTED,
+      entityType: EntityType.PLAYLIST,
+      entityId: changeRequest.playlistId,
+      metadata: {
+        changeRequestId: changeRequest.id,
+        action: changeRequest.action,
+        requestedByUserId: changeRequest.requestedById,
+        reason: changeRequest.rejectionReason,
+      },
+    });
+
+    throw new BadRequestException(changeRequest.rejectionReason);
+  }
+
+  private extractExceptionMessage(
+    error: BadRequestException | ForbiddenException | NotFoundException,
+    fallbackMessage: string,
+  ): string {
+    const response = error.getResponse();
+
+    if (typeof response === "string") {
+      return response;
+    }
+
+    if (
+      typeof response === "object" &&
+      response !== null &&
+      "message" in response
+    ) {
+      const message = response.message;
+
+      if (Array.isArray(message)) {
+        return message.join(", ");
+      }
+
+      if (typeof message === "string") {
+        return message;
+      }
+    }
+
+    return fallbackMessage;
   }
 
   private async ensureTrackIsValidForAdd(


### PR DESCRIPTION
## Summary
This PR comes from the `drips4/tip-tune` fork and targets the original repo: https://github.com/OlufunbiIK/tip-tune

- replace hard comment deletes with tombstones so reply chains stay intact
- add cursor pagination and explicit `newest` / `most-liked` sort modes for top-level comment feeds with bounded reply hydration
- make comment likes idempotent and counter-safe, and add a repair service for drifted `likesCount`
- set playlist change request expiry defaults and revalidate permissions and track state at approval time

Closes #488
Closes #489
Closes #490
Closes #491

## Validation
- `npx jest --runInBand --config ... src/comments/comments.service.spec.ts src/comments/comment-like-repair.service.spec.ts src/playlists/playlists.service.spec.ts src/playlists/playlist-change-request.validator.spec.ts`
- the committed `backend/test/jest-unit.json` config is rooted at `backend/test`, so I used a local Jest root override to run the touched `src/**/*.spec.ts` suites cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Cursor-based pagination for comment feeds with sorting options (newest/most-liked)
  * Limited reply display per comment (default 3 replies)
  * Change request expiration (7-day TTL) with automatic cleanup
  * Rejection reasons for change request rejections

* **Bug Fixes**
  * Soft-delete comments (displayed as "[deleted]")
  * Comment like count repair utility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->