### PR TITLE
feat: allowlist enumeration, pool query indexes, tipper caps, and escrowed funding

### DIFF
--- a/contracts/artist-allowlist/src/indexes.rs
+++ b/contracts/artist-allowlist/src/indexes.rs
@@ -1,0 +1,68 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum IndexKey {
+    ArtistEntries(Address),
+}
+
+pub fn add_to_index(env: &Env, artist: &Address, address: &Address) {
+    let key = IndexKey::ArtistEntries(artist.clone());
+    let mut entries: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    entries.push_back(address.clone());
+    env.storage().persistent().set(&key, &entries);
+}
+
+pub fn remove_from_index(env: &Env, artist: &Address, address: &Address) {
+    let key = IndexKey::ArtistEntries(artist.clone());
+    if let Some(mut entries) = env
+        .storage()
+        .persistent()
+        .get::<IndexKey, Vec<Address>>(&key)
+    {
+        let len = entries.len();
+        for i in 0..len {
+            if entries.get(i).unwrap() == *address {
+                let last = entries.pop_back().unwrap();
+                if i < entries.len() {
+                    entries.set(i, last);
+                }
+                break;
+            }
+        }
+        env.storage().persistent().set(&key, &entries);
+    }
+}
+
+pub fn get_page(env: &Env, artist: &Address, page: u32, page_size: u32) -> Vec<Address> {
+    if page_size == 0 || page_size > 100 {
+        return Vec::new(env);
+    }
+    let key = IndexKey::ArtistEntries(artist.clone());
+    let entries: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    let start = page * page_size;
+    let total = entries.len();
+    let end = (start + page_size).min(total);
+    let mut result = Vec::new(env);
+    for i in start..end {
+        result.push_back(entries.get(i).unwrap());
+    }
+    result
+}
+
+pub fn get_count(env: &Env, artist: &Address) -> u32 {
+    let key = IndexKey::ArtistEntries(artist.clone());
+    env.storage()
+        .persistent()
+        .get::<IndexKey, Vec<Address>>(&key)
+        .map(|v| v.len())
+        .unwrap_or(0)
+}

--- a/contracts/artist-allowlist/src/lib.rs
+++ b/contracts/artist-allowlist/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+mod indexes;
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Vec,
 };
@@ -151,6 +153,8 @@ impl ArtistAllowlistContract {
             .persistent()
             .set(&DataKey::Entry(artist.clone(), address.clone()), &entry);
 
+        indexes::add_to_index(&env, &artist, &address);
+
         env.events().publish(
             (symbol_short!("allowlst"), symbol_short!("added")),
             (artist, address),
@@ -174,6 +178,8 @@ impl ArtistAllowlistContract {
         env.storage()
             .persistent()
             .remove(&DataKey::Entry(artist.clone(), address.clone()));
+
+        indexes::remove_from_index(&env, &artist, &address);
 
         env.events().publish(
             (symbol_short!("allowlst"), symbol_short!("removed")),
@@ -278,6 +284,8 @@ impl ArtistAllowlistContract {
                 .persistent()
                 .set(&DataKey::Entry(artist.clone(), address.clone()), &entry);
 
+            indexes::add_to_index(&env, &artist, &address);
+
             env.events().publish(
                 (symbol_short!("allowlst"), symbol_short!("batch")),
                 (artist.clone(), address.clone()),
@@ -317,6 +325,8 @@ impl ArtistAllowlistContract {
                 .persistent()
                 .remove(&DataKey::Entry(artist.clone(), address.clone()));
 
+            indexes::remove_from_index(&env, &artist, &address);
+
             env.events().publish(
                 (symbol_short!("allowlst"), symbol_short!("brem")),
                 (artist.clone(), address.clone()),
@@ -333,6 +343,17 @@ impl ArtistAllowlistContract {
             .persistent()
             .get(&DataKey::TokenGate(artist))
             .ok_or(Error::TokenGateNotFound)
+    }
+
+    /// Return a page of allowlist entries for an artist.
+    /// page is zero-based; page_size must be 1–100.
+    pub fn list_allowlist(env: Env, artist: Address, page: u32, page_size: u32) -> Vec<Address> {
+        indexes::get_page(&env, &artist, page, page_size)
+    }
+
+    /// Return the total number of addresses on an artist's allowlist.
+    pub fn get_allowlist_count(env: Env, artist: Address) -> u32 {
+        indexes::get_count(&env, &artist)
     }
 }
 

--- a/contracts/artist-allowlist/src/test.rs
+++ b/contracts/artist-allowlist/src/test.rs
@@ -487,6 +487,109 @@ fn test_batch_remove_partial_atomicity() {
     assert_eq!(client.is_on_allowlist(&artist, &tipper2), true);
 }
 
+// Enumeration and pagination tests
+#[test]
+fn test_list_allowlist_basic() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, ArtistAllowlistContract);
+    let client = ArtistAllowlistContractClient::new(&env, &contract_id);
+
+    let artist = Address::generate(&env);
+    let tipper1 = Address::generate(&env);
+    let tipper2 = Address::generate(&env);
+    let tipper3 = Address::generate(&env);
+
+    client.add_to_allowlist(&artist, &tipper1);
+    client.add_to_allowlist(&artist, &tipper2);
+    client.add_to_allowlist(&artist, &tipper3);
+
+    let page = client.list_allowlist(&artist, &0, &10);
+    assert_eq!(page.len(), 3);
+}
+
+#[test]
+fn test_get_allowlist_count() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, ArtistAllowlistContract);
+    let client = ArtistAllowlistContractClient::new(&env, &contract_id);
+
+    let artist = Address::generate(&env);
+    assert_eq!(client.get_allowlist_count(&artist), 0);
+
+    let tipper1 = Address::generate(&env);
+    let tipper2 = Address::generate(&env);
+    client.add_to_allowlist(&artist, &tipper1);
+    client.add_to_allowlist(&artist, &tipper2);
+    assert_eq!(client.get_allowlist_count(&artist), 2);
+
+    client.remove_from_allowlist(&artist, &tipper1);
+    assert_eq!(client.get_allowlist_count(&artist), 1);
+}
+
+#[test]
+fn test_list_allowlist_pagination() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, ArtistAllowlistContract);
+    let client = ArtistAllowlistContractClient::new(&env, &contract_id);
+
+    let artist = Address::generate(&env);
+    let tippers: soroban_sdk::Vec<Address> = soroban_sdk::vec![
+        &env,
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+    ];
+    client.add_batch_to_allowlist(&artist, &tippers);
+
+    let page0 = client.list_allowlist(&artist, &0, &2);
+    assert_eq!(page0.len(), 2);
+
+    let page1 = client.list_allowlist(&artist, &1, &2);
+    assert_eq!(page1.len(), 2);
+
+    let page2 = client.list_allowlist(&artist, &2, &2);
+    assert_eq!(page2.len(), 1);
+
+    let page3 = client.list_allowlist(&artist, &3, &2);
+    assert_eq!(page3.len(), 0);
+}
+
+#[test]
+fn test_list_allowlist_count_reflects_removes() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, ArtistAllowlistContract);
+    let client = ArtistAllowlistContractClient::new(&env, &contract_id);
+
+    let artist = Address::generate(&env);
+    let tipper1 = Address::generate(&env);
+    let tipper2 = Address::generate(&env);
+    let tipper3 = Address::generate(&env);
+
+    let addresses = soroban_sdk::vec![&env, tipper1.clone(), tipper2.clone(), tipper3.clone()];
+    client.add_batch_to_allowlist(&artist, &addresses);
+    assert_eq!(client.get_allowlist_count(&artist), 3);
+
+    client.remove_from_allowlist(&artist, &tipper2);
+    assert_eq!(client.get_allowlist_count(&artist), 2);
+
+    let page = client.list_allowlist(&artist, &0, &10);
+    assert_eq!(page.len(), 2);
+}
+
+#[test]
+fn test_list_allowlist_empty_artist() {
+    let env = setup_env();
+    let contract_id = env.register_contract(None, ArtistAllowlistContract);
+    let client = ArtistAllowlistContractClient::new(&env, &contract_id);
+
+    let artist = Address::generate(&env);
+    let page = client.list_allowlist(&artist, &0, &10);
+    assert_eq!(page.len(), 0);
+    assert_eq!(client.get_allowlist_count(&artist), 0);
+}
+
 // Token gate hardening tests
 #[test]
 fn test_get_token_gate_found() {

--- a/contracts/drip-tip-matching/src/custody.rs
+++ b/contracts/drip-tip-matching/src/custody.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::{token, Address, Env};
+
+pub fn deposit(env: &Env, token: &Address, from: &Address, amount: i128) {
+    token::Client::new(env, token).transfer(from, &env.current_contract_address(), &amount);
+}
+
+pub fn withdraw(env: &Env, token: &Address, to: &Address, amount: i128) {
+    token::Client::new(env, token).transfer(&env.current_contract_address(), to, &amount);
+}

--- a/contracts/drip-tip-matching/src/errors.rs
+++ b/contracts/drip-tip-matching/src/errors.rs
@@ -16,4 +16,6 @@ pub enum Error {
     MatchWouldExceedCap = 10,
     PoolAlreadyRefunded = 11,
     InvalidCloseStatus = 12,
+    TipperCapExceeded = 13,
+    DuplicateTip = 14,
 }

--- a/contracts/drip-tip-matching/src/indexes.rs
+++ b/contracts/drip-tip-matching/src/indexes.rs
@@ -1,0 +1,33 @@
+use soroban_sdk::{contracttype, Address, Env, String};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum TipperKey {
+    Matched(String, Address),
+    TipUsed(String, String),
+}
+
+pub fn get_tipper_matched(env: &Env, pool_id: &String, tipper: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&TipperKey::Matched(pool_id.clone(), tipper.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_tipper_matched(env: &Env, pool_id: &String, tipper: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&TipperKey::Matched(pool_id.clone(), tipper.clone()), &amount);
+}
+
+pub fn is_tip_used(env: &Env, pool_id: &String, tip_id: &String) -> bool {
+    env.storage()
+        .persistent()
+        .has(&TipperKey::TipUsed(pool_id.clone(), tip_id.clone()))
+}
+
+pub fn mark_tip_used(env: &Env, pool_id: &String, tip_id: &String) {
+    env.storage()
+        .persistent()
+        .set(&TipperKey::TipUsed(pool_id.clone(), tip_id.clone()), &true);
+}

--- a/contracts/drip-tip-matching/src/lib.rs
+++ b/contracts/drip-tip-matching/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Ve
 
 mod errors;
 mod events;
+mod indexes;
 mod queries;
 mod types;
 
@@ -75,6 +76,7 @@ impl TipMatchingContract {
         pool_amount: i128,
         match_ratio: u32,
         match_cap_total: i128,
+        tipper_cap: i128,
         end_time: u64,
     ) -> Result<String, Error> {
         sponsor.require_auth();
@@ -89,6 +91,9 @@ impl TipMatchingContract {
         if match_cap_total < 0 {
             return Err(Error::InvalidMatchCap);
         }
+        if tipper_cap < 0 {
+            return Err(Error::InvalidParameters);
+        }
 
         let pool_id = next_pool_id(&env);
         let pool = MatchingPool {
@@ -100,6 +105,7 @@ impl TipMatchingContract {
             remaining_amount: pool_amount,
             match_ratio,
             match_cap_total,
+            tipper_cap,
             start_time: now,
             end_time,
             status: PoolStatus::Active,
@@ -119,11 +125,16 @@ impl TipMatchingContract {
         pool_id: String,
         tip_amount: i128,
         tipper: Address,
+        tip_id: String,
     ) -> Result<i128, Error> {
         tipper.require_auth();
 
         if tip_amount <= 0 {
             return Err(Error::InvalidParameters);
+        }
+
+        if indexes::is_tip_used(&env, &pool_id, &tip_id) {
+            return Err(Error::DuplicateTip);
         }
 
         let mut pool = load_pool(&env, &pool_id)?;
@@ -167,6 +178,20 @@ impl TipMatchingContract {
             }
         }
 
+        if pool.tipper_cap > 0 {
+            let already_matched = indexes::get_tipper_matched(&env, &pool_id, &tipper);
+            let tipper_remaining = pool
+                .tipper_cap
+                .checked_sub(already_matched)
+                .unwrap_or(0);
+            if tipper_remaining <= 0 {
+                return Err(Error::TipperCapExceeded);
+            }
+            if actual_match > tipper_remaining {
+                actual_match = tipper_remaining;
+            }
+        }
+
         pool.matched_amount = pool
             .matched_amount
             .checked_add(actual_match)
@@ -177,6 +202,12 @@ impl TipMatchingContract {
             .ok_or(Error::InsufficientPoolAmount)?;
         refresh_pool_status(&env, &mut pool);
         save_pool(&env, &pool);
+
+        let new_tipper_total = indexes::get_tipper_matched(&env, &pool_id, &tipper)
+            .checked_add(actual_match)
+            .unwrap_or(actual_match);
+        indexes::set_tipper_matched(&env, &pool_id, &tipper, new_tipper_total);
+        indexes::mark_tip_used(&env, &pool_id, &tip_id);
 
         env.events().publish(
             (symbol_short!("pool"), symbol_short!("match")),

--- a/contracts/drip-tip-matching/src/lib.rs
+++ b/contracts/drip-tip-matching/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Vec};
 
 mod errors;
 mod events;
+mod queries;
 mod types;
 
 pub use errors::Error;
@@ -92,8 +93,8 @@ impl TipMatchingContract {
         let pool_id = next_pool_id(&env);
         let pool = MatchingPool {
             pool_id: pool_id.clone(),
-            sponsor,
-            artist,
+            sponsor: sponsor.clone(),
+            artist: artist.clone(),
             pool_amount,
             matched_amount: 0,
             remaining_amount: pool_amount,
@@ -107,6 +108,8 @@ impl TipMatchingContract {
         };
 
         save_pool(&env, &pool);
+        queries::add_to_sponsor_index(&env, &sponsor, &pool_id);
+        queries::add_to_artist_index(&env, &artist, &pool_id);
         events::emit_pool_created(&env, &pool_id);
         Ok(pool_id)
     }
@@ -240,5 +243,13 @@ impl TipMatchingContract {
 
     pub fn get_matched_amount(env: Env, pool_id: String) -> Result<i128, Error> {
         Ok(Self::get_pool_status(env, pool_id)?.matched_amount)
+    }
+
+    pub fn list_pools_by_sponsor(env: Env, sponsor: Address) -> Vec<String> {
+        queries::get_pools_by_sponsor(&env, &sponsor)
+    }
+
+    pub fn list_pools_by_artist(env: Env, artist: Address) -> Vec<String> {
+        queries::get_pools_by_artist(&env, &artist)
     }
 }

--- a/contracts/drip-tip-matching/src/lib.rs
+++ b/contracts/drip-tip-matching/src/lib.rs
@@ -2,6 +2,7 @@
 
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Vec};
 
+mod custody;
 mod errors;
 mod events;
 mod indexes;
@@ -73,6 +74,7 @@ impl TipMatchingContract {
         env: Env,
         sponsor: Address,
         artist: Address,
+        token: Address,
         pool_amount: i128,
         match_ratio: u32,
         match_cap_total: i128,
@@ -95,11 +97,14 @@ impl TipMatchingContract {
             return Err(Error::InvalidParameters);
         }
 
+        custody::deposit(&env, &token, &sponsor, pool_amount);
+
         let pool_id = next_pool_id(&env);
         let pool = MatchingPool {
             pool_id: pool_id.clone(),
             sponsor: sponsor.clone(),
             artist: artist.clone(),
+            token,
             pool_amount,
             matched_amount: 0,
             remaining_amount: pool_amount,
@@ -209,6 +214,8 @@ impl TipMatchingContract {
         indexes::set_tipper_matched(&env, &pool_id, &tipper, new_tipper_total);
         indexes::mark_tip_used(&env, &pool_id, &tip_id);
 
+        custody::withdraw(&env, &pool.token, &pool.artist, actual_match);
+
         env.events().publish(
             (symbol_short!("pool"), symbol_short!("match")),
             (pool_id.clone(), tipper.clone(), actual_match),
@@ -241,6 +248,10 @@ impl TipMatchingContract {
         pool.status = PoolStatus::Cancelled;
         pool.refunded_at = env.ledger().timestamp();
         save_pool(&env, &pool);
+
+        if refund > 0 {
+            custody::withdraw(&env, &pool.token, &pool.sponsor, refund);
+        }
 
         events::emit_pool_cancelled(&env, &pool_id, refund);
         Ok(refund)

--- a/contracts/drip-tip-matching/src/queries.rs
+++ b/contracts/drip-tip-matching/src/queries.rs
@@ -1,0 +1,44 @@
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum QueryKey {
+    SponsorPools(Address),
+    ArtistPools(Address),
+}
+
+pub fn add_to_sponsor_index(env: &Env, sponsor: &Address, pool_id: &String) {
+    let key = QueryKey::SponsorPools(sponsor.clone());
+    let mut ids: Vec<String> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    ids.push_back(pool_id.clone());
+    env.storage().persistent().set(&key, &ids);
+}
+
+pub fn add_to_artist_index(env: &Env, artist: &Address, pool_id: &String) {
+    let key = QueryKey::ArtistPools(artist.clone());
+    let mut ids: Vec<String> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    ids.push_back(pool_id.clone());
+    env.storage().persistent().set(&key, &ids);
+}
+
+pub fn get_pools_by_sponsor(env: &Env, sponsor: &Address) -> Vec<String> {
+    env.storage()
+        .persistent()
+        .get(&QueryKey::SponsorPools(sponsor.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn get_pools_by_artist(env: &Env, artist: &Address) -> Vec<String> {
+    env.storage()
+        .persistent()
+        .get(&QueryKey::ArtistPools(artist.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/contracts/drip-tip-matching/src/types.rs
+++ b/contracts/drip-tip-matching/src/types.rs
@@ -21,6 +21,7 @@ pub struct MatchingPool {
     pub remaining_amount: i128, // Sponsor's unmatched remaining balance
     pub match_ratio: u32,       // 100 = 1:1 match
     pub match_cap_total: i128,  // Maximum total matches allowed (optional cap)
+    pub tipper_cap: i128,       // Per-tipper match ceiling per pool (0 = unlimited)
     pub start_time: u64,
     pub end_time: u64,
     pub status: PoolStatus,

--- a/contracts/drip-tip-matching/src/types.rs
+++ b/contracts/drip-tip-matching/src/types.rs
@@ -16,6 +16,7 @@ pub struct MatchingPool {
     pub pool_id: String,
     pub sponsor: Address,
     pub artist: Address,
+    pub token: Address,         // Token held in escrow for this pool
     pub pool_amount: i128,      // Sponsor's total contributed amount
     pub matched_amount: i128,   // Total amount already matched
     pub remaining_amount: i128, // Sponsor's unmatched remaining balance

--- a/contracts/drip-tip-matching/tests/matching_pool_tests.rs
+++ b/contracts/drip-tip-matching/tests/matching_pool_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use drip_tip_matching::{PoolStatus, TipMatchingContract, TipMatchingContractClient};
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
 
 fn setup() -> (Env, Address, Address, Address, Address) {
     let env = Env::default();
@@ -16,6 +16,10 @@ fn setup() -> (Env, Address, Address, Address, Address) {
     (env, contract_id, sponsor, artist, tipper)
 }
 
+fn tip_id(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
+
 #[test]
 fn test_matching_pool_lifecycle() {
     let (env, contract_id, sponsor, artist, tipper) = setup();
@@ -26,10 +30,11 @@ fn test_matching_pool_lifecycle() {
         &1000,
         &100,
         &0,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
-    let matched = client.apply_match(&pool_id, &100, &tipper);
+    let matched = client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"));
     assert_eq!(matched, 100);
 
     let pool = client.get_pool_status(&pool_id);
@@ -47,11 +52,12 @@ fn test_apply_match_respects_ratio_and_cap() {
         &10_000,
         &50,
         &500,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
-    assert_eq!(client.apply_match(&pool_id, &300, &tipper), 150);
-    assert_eq!(client.apply_match(&pool_id, &1_000, &tipper), 350);
+    assert_eq!(client.apply_match(&pool_id, &300, &tipper, &tip_id(&env, "t1")), 150);
+    assert_eq!(client.apply_match(&pool_id, &1_000, &tipper, &tip_id(&env, "t2")), 350);
 
     let pool = client.get_pool_status(&pool_id);
     assert_eq!(pool.matched_amount, 500);
@@ -68,10 +74,11 @@ fn test_apply_match_caps_to_remaining_budget() {
         &100,
         &100,
         &0,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
-    let matched = client.apply_match(&pool_id, &200, &tipper);
+    let matched = client.apply_match(&pool_id, &200, &tipper, &tip_id(&env, "t1"));
     assert_eq!(matched, 100);
 
     let pool = client.get_pool_status(&pool_id);
@@ -82,13 +89,13 @@ fn test_apply_match_caps_to_remaining_budget() {
 fn test_expired_pool_cannot_match() {
     let (env, contract_id, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(&sponsor, &artist, &1000, &100, &0, &1100);
+    let pool_id = client.create_matching_pool(&sponsor, &artist, &1000, &100, &0, &0, &1100);
 
     env.ledger().with_mut(|li| {
         li.timestamp = 1200;
     });
 
-    assert!(client.try_apply_match(&pool_id, &100, &tipper).is_err());
+    assert!(client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1")).is_err());
     assert!(!client.is_pool_active(&pool_id));
 }
 
@@ -102,10 +109,11 @@ fn test_cancel_pool_returns_remaining_budget_once() {
         &1000,
         &100,
         &0,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
-    client.apply_match(&pool_id, &250, &tipper);
+    client.apply_match(&pool_id, &250, &tipper, &tip_id(&env, "t1"));
     assert_eq!(client.cancel_pool(&pool_id, &sponsor), 750);
     assert!(client.try_cancel_pool(&pool_id, &sponsor).is_err());
 }
@@ -120,10 +128,11 @@ fn test_close_pool_after_exhaustion() {
         &100,
         &100,
         &0,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
-    client.apply_match(&pool_id, &100, &tipper);
+    client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"));
     client.close_pool(&pool_id);
 
     let pool = client.get_pool_status(&pool_id);
@@ -140,13 +149,106 @@ fn test_budget_accessors_track_pool_state() {
         &1000,
         &100,
         &0,
+        &0,
         &(env.ledger().timestamp() + 1000),
     );
 
     assert_eq!(client.get_remaining_budget(&pool_id), 1000);
     assert_eq!(client.get_matched_amount(&pool_id), 0);
 
-    client.apply_match(&pool_id, &250, &tipper);
+    client.apply_match(&pool_id, &250, &tipper, &tip_id(&env, "t1"));
     assert_eq!(client.get_remaining_budget(&pool_id), 750);
     assert_eq!(client.get_matched_amount(&pool_id), 250);
+}
+
+#[test]
+fn test_duplicate_tip_rejected() {
+    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+    let pool_id = client.create_matching_pool(
+        &sponsor,
+        &artist,
+        &1000,
+        &100,
+        &0,
+        &0,
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "tip-abc"));
+    let result = client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "tip-abc"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_tipper_cap_enforced() {
+    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+    let pool_id = client.create_matching_pool(
+        &sponsor,
+        &artist,
+        &1000,
+        &100,
+        &0,
+        &200,
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    assert_eq!(client.apply_match(&pool_id, &150, &tipper, &tip_id(&env, "t1")), 150);
+    assert_eq!(client.apply_match(&pool_id, &150, &tipper, &tip_id(&env, "t2")), 50);
+    let result = client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t3"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_tipper_cap_independent_per_tipper() {
+    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let tipper2 = Address::generate(&env);
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+    let pool_id = client.create_matching_pool(
+        &sponsor,
+        &artist,
+        &1000,
+        &100,
+        &0,
+        &100,
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    assert_eq!(client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1")), 100);
+    assert!(client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t2")).is_err());
+    assert_eq!(client.apply_match(&pool_id, &100, &tipper2, &tip_id(&env, "t3")), 100);
+}
+
+#[test]
+fn test_query_indexes_by_sponsor_and_artist() {
+    let (env, contract_id, sponsor, artist, _tipper) = setup();
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+
+    let pool1 = client.create_matching_pool(
+        &sponsor,
+        &artist,
+        &500,
+        &100,
+        &0,
+        &0,
+        &(env.ledger().timestamp() + 1000),
+    );
+    let pool2 = client.create_matching_pool(
+        &sponsor,
+        &artist,
+        &300,
+        &100,
+        &0,
+        &0,
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    let by_sponsor = client.list_pools_by_sponsor(&sponsor);
+    assert_eq!(by_sponsor.len(), 2);
+    assert!(by_sponsor.contains(&pool1));
+    assert!(by_sponsor.contains(&pool2));
+
+    let by_artist = client.list_pools_by_artist(&artist);
+    assert_eq!(by_artist.len(), 2);
 }

--- a/contracts/drip-tip-matching/tests/matching_pool_tests.rs
+++ b/contracts/drip-tip-matching/tests/matching_pool_tests.rs
@@ -1,38 +1,62 @@
 #![cfg(test)]
 
 use drip_tip_matching::{PoolStatus, TipMatchingContract, TipMatchingContractClient};
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Ledger as _, token, Address, Env, String,
+};
 
-fn setup() -> (Env, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000);
 
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let sac = token::StellarAssetClient::new(&env, &token_address);
+
     let sponsor = Address::generate(&env);
     let artist = Address::generate(&env);
     let tipper = Address::generate(&env);
+    sac.mint(&sponsor, &100_000);
+
     let contract_id = env.register_contract(None, TipMatchingContract);
 
-    (env, contract_id, sponsor, artist, tipper)
+    (env, contract_id, token_address, sponsor, artist, tipper)
 }
 
 fn tip_id(env: &Env, s: &str) -> String {
     String::from_str(env, s)
 }
 
+fn create_pool(
+    client: &TipMatchingContractClient,
+    env: &Env,
+    token: &Address,
+    sponsor: &Address,
+    artist: &Address,
+    amount: i128,
+    ratio: u32,
+    cap_total: i128,
+    tipper_cap: i128,
+) -> String {
+    client.create_matching_pool(
+        sponsor,
+        artist,
+        token,
+        &amount,
+        &ratio,
+        &cap_total,
+        &tipper_cap,
+        &(env.ledger().timestamp() + 1000),
+    )
+}
+
 #[test]
 fn test_matching_pool_lifecycle() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
 
     let matched = client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"));
     assert_eq!(matched, 100);
@@ -44,17 +68,9 @@ fn test_matching_pool_lifecycle() {
 
 #[test]
 fn test_apply_match_respects_ratio_and_cap() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &10_000,
-        &50,
-        &500,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 10_000, 50, 500, 0);
 
     assert_eq!(client.apply_match(&pool_id, &300, &tipper, &tip_id(&env, "t1")), 150);
     assert_eq!(client.apply_match(&pool_id, &1_000, &tipper, &tip_id(&env, "t2")), 350);
@@ -66,17 +82,9 @@ fn test_apply_match_respects_ratio_and_cap() {
 
 #[test]
 fn test_apply_match_caps_to_remaining_budget() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &100,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 100, 100, 0, 0);
 
     let matched = client.apply_match(&pool_id, &200, &tipper, &tip_id(&env, "t1"));
     assert_eq!(matched, 100);
@@ -87,31 +95,27 @@ fn test_apply_match_caps_to_remaining_budget() {
 
 #[test]
 fn test_expired_pool_cannot_match() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(&sponsor, &artist, &1000, &100, &0, &0, &1100);
+    let pool_id = client.create_matching_pool(
+        &sponsor, &artist, &token, &1000, &100, &0, &0, &1100,
+    );
 
     env.ledger().with_mut(|li| {
         li.timestamp = 1200;
     });
 
-    assert!(client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1")).is_err());
+    assert!(client
+        .try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"))
+        .is_err());
     assert!(!client.is_pool_active(&pool_id));
 }
 
 #[test]
 fn test_cancel_pool_returns_remaining_budget_once() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
 
     client.apply_match(&pool_id, &250, &tipper, &tip_id(&env, "t1"));
     assert_eq!(client.cancel_pool(&pool_id, &sponsor), 750);
@@ -120,17 +124,9 @@ fn test_cancel_pool_returns_remaining_budget_once() {
 
 #[test]
 fn test_close_pool_after_exhaustion() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &100,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 100, 100, 0, 0);
 
     client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"));
     client.close_pool(&pool_id);
@@ -141,17 +137,9 @@ fn test_close_pool_after_exhaustion() {
 
 #[test]
 fn test_budget_accessors_track_pool_state() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
 
     assert_eq!(client.get_remaining_budget(&pool_id), 1000);
     assert_eq!(client.get_matched_amount(&pool_id), 0);
@@ -163,17 +151,9 @@ fn test_budget_accessors_track_pool_state() {
 
 #[test]
 fn test_duplicate_tip_rejected() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
 
     client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "tip-abc"));
     let result = client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "tip-abc"));
@@ -182,17 +162,9 @@ fn test_duplicate_tip_rejected() {
 
 #[test]
 fn test_tipper_cap_enforced() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &200,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 200);
 
     assert_eq!(client.apply_match(&pool_id, &150, &tipper, &tip_id(&env, "t1")), 150);
     assert_eq!(client.apply_match(&pool_id, &150, &tipper, &tip_id(&env, "t2")), 50);
@@ -202,47 +174,25 @@ fn test_tipper_cap_enforced() {
 
 #[test]
 fn test_tipper_cap_independent_per_tipper() {
-    let (env, contract_id, sponsor, artist, tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
     let tipper2 = Address::generate(&env);
     let client = TipMatchingContractClient::new(&env, &contract_id);
-    let pool_id = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &1000,
-        &100,
-        &0,
-        &100,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 100);
 
     assert_eq!(client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1")), 100);
-    assert!(client.try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t2")).is_err());
+    assert!(client
+        .try_apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t2"))
+        .is_err());
     assert_eq!(client.apply_match(&pool_id, &100, &tipper2, &tip_id(&env, "t3")), 100);
 }
 
 #[test]
 fn test_query_indexes_by_sponsor_and_artist() {
-    let (env, contract_id, sponsor, artist, _tipper) = setup();
+    let (env, contract_id, token, sponsor, artist, _tipper) = setup();
     let client = TipMatchingContractClient::new(&env, &contract_id);
 
-    let pool1 = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &500,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
-    let pool2 = client.create_matching_pool(
-        &sponsor,
-        &artist,
-        &300,
-        &100,
-        &0,
-        &0,
-        &(env.ledger().timestamp() + 1000),
-    );
+    let pool1 = create_pool(&client, &env, &token, &sponsor, &artist, 500, 100, 0, 0);
+    let pool2 = create_pool(&client, &env, &token, &sponsor, &artist, 300, 100, 0, 0);
 
     let by_sponsor = client.list_pools_by_sponsor(&sponsor);
     assert_eq!(by_sponsor.len(), 2);
@@ -251,4 +201,39 @@ fn test_query_indexes_by_sponsor_and_artist() {
 
     let by_artist = client.list_pools_by_artist(&artist);
     assert_eq!(by_artist.len(), 2);
+}
+
+#[test]
+fn test_pool_funding_backed_by_escrow() {
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+    let token_client = token::Client::new(&env, &token);
+
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
+
+    let contract_balance_after_create = token_client.balance(&contract_id);
+    assert_eq!(contract_balance_after_create, 1000);
+
+    client.apply_match(&pool_id, &200, &tipper, &tip_id(&env, "t1"));
+    assert_eq!(token_client.balance(&contract_id), 800);
+    assert_eq!(token_client.balance(&artist), 200);
+}
+
+#[test]
+fn test_cancel_pool_refunds_token_to_sponsor() {
+    let (env, contract_id, token, sponsor, artist, tipper) = setup();
+    let client = TipMatchingContractClient::new(&env, &contract_id);
+    let token_client = token::Client::new(&env, &token);
+
+    let sponsor_balance_before = token_client.balance(&sponsor);
+    let pool_id = create_pool(&client, &env, &token, &sponsor, &artist, 1000, 100, 0, 0);
+
+    client.apply_match(&pool_id, &100, &tipper, &tip_id(&env, "t1"));
+    assert_eq!(client.cancel_pool(&pool_id, &sponsor), 900);
+
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(
+        token_client.balance(&sponsor),
+        sponsor_balance_before - 100
+    );
 }


### PR DESCRIPTION
## Summary

- **#517** — `artist-allowlist`: add `indexes.rs` with per-artist ordered entry list; expose `list_allowlist(page, page_size)` and `get_allowlist_count` on the contract; membership O(1) checks unchanged
- **#516** — `drip-tip-matching`: add `queries.rs` with sponsor/artist pool indexes maintained on `create_matching_pool`; expose `list_pools_by_sponsor` and `list_pools_by_artist` query functions
- **#515** — `drip-tip-matching`: add `indexes.rs` for per-tipper match tracking and tip deduplication; add `tipper_cap` field to `MatchingPool`; `apply_match` now requires a `tip_id` and enforces both the pool-level cap and the per-tipper ceiling
- **#514** — `drip-tip-matching`: add `custody.rs` for token transfer helpers; `create_matching_pool` now accepts a `token` parameter and locks sponsor funds on creation; `apply_match` releases matched funds to the artist; `cancel_pool` refunds remaining balance to the sponsor

## Test plan

- [ ] `cargo test -p artist-allowlist` — 37 tests pass (includes 5 new pagination/count tests)
- [ ] `cargo test -p drip-tip-matching` — 13 tests pass (includes duplicate-tip rejection, tipper-cap exhaustion, escrow balance assertions, and refund verification)

Closes #514
Closes #515
Closes #516
Closes #517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allowlist pagination with count queries for artist entries
  * Implemented per-tipper matching limits and duplicate tip prevention
  * Enabled pool discovery by sponsor or artist address
  * Added token custody with escrow, deposit, and refund functionality

* **Tests**
  * Added comprehensive test coverage for pagination, enumeration, and matching cap enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->