### PR TITLE
feat(tip-verification): add secondary indexes and getter APIs for tx-…

### DIFF
--- a/contracts/tip-verification/src/indexes.rs
+++ b/contracts/tip-verification/src/indexes.rs
@@ -1,0 +1,72 @@
+//! Secondary indexes for tip-verification contract.
+//! Provides efficient lookup by tx_hash and artist.
+
+use crate::DataKey;
+use soroban_sdk::{Address, Env, String};
+
+/// Index from tx_hash to tip_id for O(1) lookup by transaction hash.
+pub fn set_tx_hash_to_tip_id(env: &Env, tx_hash: &String, tip_id: &String) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TxHashToTipId(tx_hash.clone()), tip_id);
+}
+
+/// Get tip_id by tx_hash. Returns None if not found.
+pub fn get_tip_id_by_tx_hash(env: &Env, tx_hash: &String) -> Option<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TxHashToTipId(tx_hash.clone()))
+}
+
+/// Index from artist address to tip count (for iteration).
+/// We store a counter and use indexed storage for enumeration.
+pub fn set_artist_tip_count(env: &Env, artist: &Address, count: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ArtistTipCount(artist.clone()), &count);
+}
+
+/// Get tip count for an artist.
+pub fn get_artist_tip_count(env: &Env, artist: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ArtistTipCount(artist.clone()))
+        .unwrap_or(0)
+}
+
+/// Store a tip ID at a specific index for an artist.
+/// This allows enumeration of tips for a given artist.
+pub fn set_artist_tip_at_index(env: &Env, artist: &Address, index: u32, tip_id: &String) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ArtistTipIndex(artist.clone(), index), tip_id);
+}
+
+/// Get tip ID at a specific index for an artist.
+pub fn get_artist_tip_at_index(env: &Env, artist: &Address, index: u32) -> Option<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ArtistTipIndex(artist.clone(), index))
+}
+
+/// Add a tip to an artist's index.
+/// Returns the new tip count for the artist.
+pub fn add_tip_to_artist_index(env: &Env, artist: &Address, tip_id: &String) -> u32 {
+    let current_count = get_artist_tip_count(env, artist);
+    let new_count = current_count + 1;
+
+    // Store the tip at the new index
+    set_artist_tip_at_index(env, artist, current_count, tip_id);
+
+    // Update the count
+    set_artist_tip_count(env, artist, new_count);
+
+    new_count
+}
+
+/// Check if a tx_hash is already indexed (duplicate).
+pub fn has_tx_hash_index(env: &Env, tx_hash: &String) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::TxHashToTipId(tx_hash.clone()))
+}

--- a/contracts/tip-verification/src/lib.rs
+++ b/contracts/tip-verification/src/lib.rs
@@ -1,7 +1,15 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, String,
+    Vec,
+};
+
+mod indexes;
+
+use indexes::{
+    add_tip_to_artist_index, get_artist_tip_at_index, get_artist_tip_count, get_tip_id_by_tx_hash,
+    has_tx_hash_index, set_tx_hash_to_tip_id,
 };
 
 #[contracterror]
@@ -13,6 +21,9 @@ pub enum Error {
     TipNotFound = 3,
     Unauthorized = 4,
     DuplicateTipId = 5,
+    DuplicateTxHash = 6,
+    ArtistNotFound = 7,
+    InvalidIndex = 8,
 }
 
 #[contracttype]
@@ -23,6 +34,10 @@ pub enum DataKey {
     TipRecord(String),
     TipCount,
     UserTipCount(Address),
+    // Secondary indexes
+    TxHashToTipId(String),
+    ArtistTipCount(Address),
+    ArtistTipIndex(Address, u32),
 }
 
 #[contracttype]
@@ -42,7 +57,7 @@ pub struct TipVerificationContract;
 
 #[contractimpl]
 impl TipVerificationContract {
-    /// Initialize the contract with an admin address
+    /// Initialize the contract with an admin address.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
@@ -58,7 +73,6 @@ impl TipVerificationContract {
             return Err(Error::InvalidAmount);
         }
 
-        // Check if this transaction has already been verified (prevent double-spending)
         if env
             .storage()
             .persistent()
@@ -67,12 +81,10 @@ impl TipVerificationContract {
             return Err(Error::AlreadyVerified);
         }
 
-        // Mark transaction as verified
         env.storage()
             .persistent()
             .set(&DataKey::VerifiedTx(tx_hash.clone()), &true);
 
-        // Emit verification event
         env.events().publish(
             (symbol_short!("tip"), symbol_short!("verified")),
             (tx_hash, expected_amount),
@@ -82,13 +94,14 @@ impl TipVerificationContract {
     }
 
     /// Record a verified tip with full details. Immutable once recorded.
-    /// Prevents duplicate tip IDs.
+    /// Maintains secondary indexes: tx_hash → tip_id and artist → [tip_ids].
     pub fn record_verified_tip(
         env: Env,
         tip_id: String,
         tipper: Address,
         artist: Address,
         amount: i128,
+        tx_hash: String,
     ) -> Result<(), Error> {
         if amount <= 0 {
             return Err(Error::InvalidAmount);
@@ -103,23 +116,31 @@ impl TipVerificationContract {
             return Err(Error::DuplicateTipId);
         }
 
-        // Build a tx_hash from tip_id for linking
-        let tx_hash = tip_id.clone();
+        // Prevent duplicate tx_hash across all tips
+        if has_tx_hash_index(&env, &tx_hash) {
+            return Err(Error::DuplicateTxHash);
+        }
 
         let tip = VerifiedTip {
             tip_id: tip_id.clone(),
             tipper: tipper.clone(),
             artist: artist.clone(),
             amount,
-            tx_hash,
+            tx_hash: tx_hash.clone(),
             timestamp: env.ledger().timestamp(),
             verified: true,
         };
 
-        // Store the immutable record
+        // Store the primary record by tip_id
         env.storage()
             .persistent()
             .set(&DataKey::TipRecord(tip_id.clone()), &tip);
+
+        // Secondary index: tx_hash → tip_id
+        set_tx_hash_to_tip_id(&env, &tx_hash, &tip_id);
+
+        // Secondary index: artist → [tip_ids] (append)
+        add_tip_to_artist_index(&env, &artist, &tip_id);
 
         // Increment global tip count
         let count: u64 = env
@@ -131,7 +152,7 @@ impl TipVerificationContract {
             .instance()
             .set(&DataKey::TipCount, &(count + 1));
 
-        // Increment user tip count
+        // Increment per-user tip count
         let user_count: u64 = env
             .storage()
             .instance()
@@ -139,18 +160,17 @@ impl TipVerificationContract {
             .unwrap_or(0);
         env.storage()
             .instance()
-            .set(&DataKey::UserTipCount(tipper.clone()), &(user_count + 1));
+            .set(&DataKey::UserTipCount(tipper), &(user_count + 1));
 
-        // Emit recording event
         env.events().publish(
             (symbol_short!("tip"), symbol_short!("recorded")),
-            tip.clone(),
+            tip,
         );
 
         Ok(())
     }
 
-    /// Check if a transaction has already been verified
+    /// Check if a transaction has already been verified.
     pub fn is_verified(env: Env, tx_hash: String) -> bool {
         env.storage()
             .persistent()
@@ -158,7 +178,7 @@ impl TipVerificationContract {
             .unwrap_or(false)
     }
 
-    /// Get a recorded tip by its ID
+    /// Get a recorded tip by its tip ID.
     pub fn get_tip(env: Env, tip_id: String) -> Result<VerifiedTip, Error> {
         env.storage()
             .persistent()
@@ -166,7 +186,7 @@ impl TipVerificationContract {
             .ok_or(Error::TipNotFound)
     }
 
-    /// Get total number of recorded tips
+    /// Get total number of recorded tips.
     pub fn get_tip_count(env: Env) -> u64 {
         env.storage()
             .instance()
@@ -174,12 +194,61 @@ impl TipVerificationContract {
             .unwrap_or(0)
     }
 
-    /// Get total tips for a specific user
+    /// Get total tips sent by a specific user.
     pub fn get_user_tip_count(env: Env, user: Address) -> u64 {
         env.storage()
             .instance()
             .get(&DataKey::UserTipCount(user))
             .unwrap_or(0)
+    }
+
+    /// Get a verified tip by its transaction hash (secondary index lookup).
+    pub fn get_tip_by_tx_hash(env: Env, tx_hash: String) -> Result<VerifiedTip, Error> {
+        let tip_id = get_tip_id_by_tx_hash(&env, &tx_hash).ok_or(Error::TipNotFound)?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::TipRecord(tip_id))
+            .ok_or(Error::TipNotFound)
+    }
+
+    /// Get the number of tips received by an artist.
+    pub fn get_artist_tip_count(env: Env, artist: Address) -> u32 {
+        get_artist_tip_count(&env, &artist)
+    }
+
+    /// Get a specific tip for an artist by position index.
+    /// Returns InvalidIndex if the index is out of bounds.
+    pub fn get_artist_tip_at_index(
+        env: Env,
+        artist: Address,
+        index: u32,
+    ) -> Result<VerifiedTip, Error> {
+        let tip_id =
+            get_artist_tip_at_index(&env, &artist, index).ok_or(Error::InvalidIndex)?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::TipRecord(tip_id))
+            .ok_or(Error::TipNotFound)
+    }
+
+    /// List all tips received by a specific artist.
+    pub fn get_tips_for_artist(env: Env, artist: Address) -> Vec<VerifiedTip> {
+        let count = get_artist_tip_count(&env, &artist);
+        let mut tips: Vec<VerifiedTip> = vec![&env];
+
+        for i in 0..count {
+            if let Some(tip_id) = get_artist_tip_at_index(&env, &artist, i) {
+                if let Some(tip) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, VerifiedTip>(&DataKey::TipRecord(tip_id))
+                {
+                    tips.push_back(tip);
+                }
+            }
+        }
+
+        tips
     }
 }
 

--- a/contracts/tip-verification/src/test.rs
+++ b/contracts/tip-verification/src/test.rs
@@ -3,73 +3,59 @@
 use super::*;
 use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-#[test]
-fn test_initialize() {
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipVerificationContractClient<'static>) {
     let env = Env::default();
     let contract_id = env.register_contract(None, TipVerificationContract);
     let client = TipVerificationContractClient::new(&env, &contract_id);
-
     let admin = Address::generate(&env);
     client.initialize(&admin);
+    (env, client)
+}
 
+// ── original tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize() {
+    let (_, client) = setup();
     assert_eq!(client.get_tip_count(), 0);
 }
 
 #[test]
 fn test_verify_tip() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tx_hash = String::from_str(&env, "tx_abc123");
-    let result = client.verify_tip(&tx_hash, &500);
-
-    assert_eq!(result, true);
+    assert_eq!(client.verify_tip(&tx_hash, &500), true);
     assert_eq!(client.is_verified(&tx_hash), true);
 }
 
 #[test]
 fn test_prevents_double_spending() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tx_hash = String::from_str(&env, "tx_double");
-
-    // First verification succeeds
-    let result = client.verify_tip(&tx_hash, &100);
-    assert_eq!(result, true);
-
-    // Second verification should fail (double-spending)
-    let result = client.try_verify_tip(&tx_hash, &100);
-    assert_eq!(result, Err(Ok(Error::AlreadyVerified)));
+    assert_eq!(client.verify_tip(&tx_hash, &100), true);
+    assert_eq!(
+        client.try_verify_tip(&tx_hash, &100),
+        Err(Ok(Error::AlreadyVerified))
+    );
 }
 
 #[test]
 fn test_record_verified_tip() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tipper = Address::generate(&env);
     let artist = Address::generate(&env);
     let tip_id = String::from_str(&env, "tip_001");
+    let tx_hash = String::from_str(&env, "tx_001");
 
-    client.record_verified_tip(&tip_id, &tipper, &artist, &250);
+    client.record_verified_tip(&tip_id, &tipper, &artist, &250, &tx_hash);
 
     let tip = client.get_tip(&tip_id);
     assert_eq!(tip.tipper, tipper);
     assert_eq!(tip.artist, artist);
     assert_eq!(tip.amount, 250);
+    assert_eq!(tip.tx_hash, tx_hash);
     assert_eq!(tip.verified, true);
     assert_eq!(client.get_tip_count(), 1);
     assert_eq!(client.get_user_tip_count(&tipper), 1);
@@ -77,98 +63,93 @@ fn test_record_verified_tip() {
 
 #[test]
 fn test_records_immutable() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tipper = Address::generate(&env);
     let artist = Address::generate(&env);
     let tip_id = String::from_str(&env, "tip_immutable");
+    let tx_hash = String::from_str(&env, "tx_immutable");
 
-    // Record once
-    client.record_verified_tip(&tip_id, &tipper, &artist, &100);
+    client.record_verified_tip(&tip_id, &tipper, &artist, &100, &tx_hash);
 
-    // Attempt to record again with same tip_id should fail (immutability)
-    let result = client.try_record_verified_tip(&tip_id, &tipper, &artist, &200);
+    // Same tip_id → DuplicateTipId
+    let result = client.try_record_verified_tip(
+        &tip_id,
+        &tipper,
+        &artist,
+        &200,
+        &String::from_str(&env, "tx_other"),
+    );
     assert_eq!(result, Err(Ok(Error::DuplicateTipId)));
 
-    // Verify original record is unchanged
-    let tip = client.get_tip(&tip_id);
-    assert_eq!(tip.amount, 100);
+    // Original record unchanged
+    assert_eq!(client.get_tip(&tip_id).amount, 100);
 }
 
 #[test]
 fn test_invalid_amount_verify() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tx_hash = String::from_str(&env, "tx_invalid");
-
-    let result = client.try_verify_tip(&tx_hash, &0);
-    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
-
-    let result = client.try_verify_tip(&tx_hash, &-50);
-    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    assert_eq!(
+        client.try_verify_tip(&tx_hash, &0),
+        Err(Ok(Error::InvalidAmount))
+    );
+    assert_eq!(
+        client.try_verify_tip(&tx_hash, &-50),
+        Err(Ok(Error::InvalidAmount))
+    );
 }
 
 #[test]
 fn test_invalid_amount_record() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tipper = Address::generate(&env);
     let artist = Address::generate(&env);
     let tip_id = String::from_str(&env, "tip_invalid");
-
-    let result = client.try_record_verified_tip(&tip_id, &tipper, &artist, &0);
-    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    let tx_hash = String::from_str(&env, "tx_invalid_amt");
+    assert_eq!(
+        client.try_record_verified_tip(&tip_id, &tipper, &artist, &0, &tx_hash),
+        Err(Ok(Error::InvalidAmount))
+    );
 }
 
 #[test]
 fn test_tip_not_found() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tip_id = String::from_str(&env, "nonexistent");
-    let result = client.try_get_tip(&tip_id);
-    assert_eq!(result, Err(Ok(Error::TipNotFound)));
+    assert_eq!(
+        client.try_get_tip(&tip_id),
+        Err(Ok(Error::TipNotFound))
+    );
 }
 
 #[test]
 fn test_multiple_tips_counting() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let tipper = Address::generate(&env);
     let artist1 = Address::generate(&env);
     let artist2 = Address::generate(&env);
 
-    let tip1 = String::from_str(&env, "tip_a");
-    let tip2 = String::from_str(&env, "tip_b");
-    let tip3 = String::from_str(&env, "tip_c");
-
-    client.record_verified_tip(&tip1, &tipper, &artist1, &100);
-    client.record_verified_tip(&tip2, &tipper, &artist2, &200);
-    client.record_verified_tip(&tip3, &tipper, &artist1, &300);
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_a"),
+        &tipper,
+        &artist1,
+        &100,
+        &String::from_str(&env, "tx_a"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_b"),
+        &tipper,
+        &artist2,
+        &200,
+        &String::from_str(&env, "tx_b"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_c"),
+        &tipper,
+        &artist1,
+        &300,
+        &String::from_str(&env, "tx_c"),
+    );
 
     assert_eq!(client.get_tip_count(), 3);
     assert_eq!(client.get_user_tip_count(&tipper), 3);
@@ -176,13 +157,271 @@ fn test_multiple_tips_counting() {
 
 #[test]
 fn test_unverified_tx_returns_false() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, TipVerificationContract);
-    let client = TipVerificationContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    client.initialize(&admin);
-
+    let (env, client) = setup();
     let unknown_tx = String::from_str(&env, "tx_unknown");
     assert_eq!(client.is_verified(&unknown_tx), false);
+}
+
+// ── secondary index tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_get_tip_by_tx_hash() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+    let tip_id = String::from_str(&env, "tip_txhash_001");
+    let tx_hash = String::from_str(&env, "tx_hash_abc123");
+
+    client.record_verified_tip(&tip_id, &tipper, &artist, &500, &tx_hash);
+
+    let tip = client.get_tip_by_tx_hash(&tx_hash);
+    assert_eq!(tip.tip_id, tip_id);
+    assert_eq!(tip.tipper, tipper);
+    assert_eq!(tip.artist, artist);
+    assert_eq!(tip.amount, 500);
+    assert_eq!(tip.tx_hash, tx_hash);
+}
+
+#[test]
+fn test_get_tip_by_tx_hash_not_found() {
+    let (env, client) = setup();
+    let unknown_tx = String::from_str(&env, "tx_nonexistent");
+    assert_eq!(
+        client.try_get_tip_by_tx_hash(&unknown_tx),
+        Err(Ok(Error::TipNotFound))
+    );
+}
+
+#[test]
+fn test_get_artist_tip_count() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_art_1"),
+        &tipper,
+        &artist,
+        &100,
+        &String::from_str(&env, "tx_art_1"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_art_2"),
+        &tipper,
+        &artist,
+        &200,
+        &String::from_str(&env, "tx_art_2"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_art_3"),
+        &tipper,
+        &artist,
+        &300,
+        &String::from_str(&env, "tx_art_3"),
+    );
+
+    assert_eq!(client.get_artist_tip_count(&artist), 3);
+}
+
+#[test]
+fn test_get_artist_tip_count_empty() {
+    let (env, client) = setup();
+    let artist = Address::generate(&env);
+    assert_eq!(client.get_artist_tip_count(&artist), 0);
+}
+
+#[test]
+fn test_get_tips_for_artist() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_list_1"),
+        &tipper,
+        &artist,
+        &100,
+        &String::from_str(&env, "tx_list_1"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_list_2"),
+        &tipper,
+        &artist,
+        &200,
+        &String::from_str(&env, "tx_list_2"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_list_3"),
+        &tipper,
+        &artist,
+        &300,
+        &String::from_str(&env, "tx_list_3"),
+    );
+
+    let tips = client.get_tips_for_artist(&artist);
+    assert_eq!(tips.len(), 3);
+    assert_eq!(tips.get(0).unwrap().amount, 100);
+    assert_eq!(tips.get(1).unwrap().amount, 200);
+    assert_eq!(tips.get(2).unwrap().amount, 300);
+}
+
+#[test]
+fn test_get_tips_for_artist_empty() {
+    let (env, client) = setup();
+    let artist = Address::generate(&env);
+    let tips = client.get_tips_for_artist(&artist);
+    assert_eq!(tips.len(), 0);
+}
+
+#[test]
+fn test_get_artist_tip_at_index() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_idx_0"),
+        &tipper,
+        &artist,
+        &100,
+        &String::from_str(&env, "tx_idx_0"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_idx_1"),
+        &tipper,
+        &artist,
+        &200,
+        &String::from_str(&env, "tx_idx_1"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_idx_2"),
+        &tipper,
+        &artist,
+        &300,
+        &String::from_str(&env, "tx_idx_2"),
+    );
+
+    assert_eq!(client.get_artist_tip_at_index(&artist, &0).amount, 100);
+    assert_eq!(client.get_artist_tip_at_index(&artist, &1).amount, 200);
+    assert_eq!(client.get_artist_tip_at_index(&artist, &2).amount, 300);
+}
+
+#[test]
+fn test_get_artist_tip_at_index_invalid() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_valid"),
+        &tipper,
+        &artist,
+        &100,
+        &String::from_str(&env, "tx_valid"),
+    );
+
+    // Out-of-bounds index
+    assert_eq!(
+        client.try_get_artist_tip_at_index(&artist, &5),
+        Err(Ok(Error::InvalidIndex))
+    );
+}
+
+#[test]
+fn test_duplicate_tx_hash_protection() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+    let shared_tx_hash = String::from_str(&env, "tx_shared_hash");
+
+    // First tip with this tx_hash succeeds
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_dup_1"),
+        &tipper,
+        &artist,
+        &100,
+        &shared_tx_hash,
+    );
+
+    // Second tip with the same tx_hash must fail
+    assert_eq!(
+        client.try_record_verified_tip(
+            &String::from_str(&env, "tip_dup_2"),
+            &tipper,
+            &artist,
+            &200,
+            &shared_tx_hash,
+        ),
+        Err(Ok(Error::DuplicateTxHash))
+    );
+}
+
+#[test]
+fn test_index_integrity_after_recording() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist = Address::generate(&env);
+    let tip_id = String::from_str(&env, "tip_integrity");
+    let tx_hash = String::from_str(&env, "tx_integrity");
+
+    client.record_verified_tip(&tip_id, &tipper, &artist, &500, &tx_hash);
+
+    // tx_hash lookup
+    let tip_by_hash = client.get_tip_by_tx_hash(&tx_hash);
+    assert_eq!(tip_by_hash.tip_id, tip_id);
+
+    // artist index
+    assert_eq!(client.get_artist_tip_count(&artist), 1);
+    assert_eq!(client.get_artist_tip_at_index(&artist, &0).tip_id, tip_id);
+
+    // artist list
+    let tips = client.get_tips_for_artist(&artist);
+    assert_eq!(tips.len(), 1);
+    assert_eq!(tips.get(0).unwrap().tip_id, tip_id);
+
+    // original tip_id path still works
+    assert_eq!(client.get_tip(&tip_id).tip_id, tip_id);
+}
+
+#[test]
+fn test_multiple_artists_indexing() {
+    let (env, client) = setup();
+    let tipper = Address::generate(&env);
+    let artist1 = Address::generate(&env);
+    let artist2 = Address::generate(&env);
+
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_multi_1"),
+        &tipper,
+        &artist1,
+        &100,
+        &String::from_str(&env, "tx_multi_1"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_multi_2"),
+        &tipper,
+        &artist2,
+        &200,
+        &String::from_str(&env, "tx_multi_2"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_multi_3"),
+        &tipper,
+        &artist1,
+        &300,
+        &String::from_str(&env, "tx_multi_3"),
+    );
+    client.record_verified_tip(
+        &String::from_str(&env, "tip_multi_4"),
+        &tipper,
+        &artist2,
+        &400,
+        &String::from_str(&env, "tx_multi_4"),
+    );
+
+    assert_eq!(client.get_artist_tip_count(&artist1), 2);
+    assert_eq!(client.get_artist_tip_count(&artist2), 2);
+    assert_eq!(client.get_tips_for_artist(&artist1).len(), 2);
+    assert_eq!(client.get_tips_for_artist(&artist2).len(), 2);
+    assert_eq!(client.get_tip_count(), 4);
 }


### PR DESCRIPTION
## Related Issue
closed #526 

## Description

The `tip-verification` contract previously stored tip records by `tip_id` and verified
tx hashes separately, with no way to retrieve a recorded tip by its transaction hash or
query all tips for a given artist. This PR adds secondary indexes and the corresponding
getter APIs to close that gap while keeping the existing `tip_id` path fully intact.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes

**`contracts/tip-verification/src/lib.rs`**
- Added `TxHashToTipId`, `ArtistTipCount`, `ArtistTipIndex` variants to `DataKey`
- Added `DuplicateTxHash` and `InvalidIndex` error variants
- Extended `record_verified_tip` with an explicit `tx_hash` parameter; indexes are
  written atomically alongside the primary record
- Added `get_tip_by_tx_hash` — O(1) lookup of a tip by its Stellar transaction hash
- Added `get_artist_tip_count` — returns how many tips an artist has received
- Added `get_artist_tip_at_index` — positional access into an artist's tip list
- Added `get_tips_for_artist` — returns all tips for an artist as a `Vec<VerifiedTip>`

**`contracts/tip-verification/src/indexes.rs`** *(new file)*
- Isolated index helpers: `set_tx_hash_to_tip_id`, `get_tip_id_by_tx_hash`,
  `set/get_artist_tip_count`, `set/get_artist_tip_at_index`, `add_tip_to_artist_index`,
  `has_tx_hash_index`

**`contracts/tip-verification/src/test.rs`**
- Added 11 new tests covering tx-hash lookup, artist queries, index integrity after
  recording, out-of-bounds index access, and duplicate `tx_hash` protection

## Testing

Checklist
 My code follows the project style guidelines
 I have performed a self-review
 I have commented complex code
 My changes generate no new warnings
 I have added tests covering all new functionality
 All new and existing tests pass
 Existing tip_id path is unchanged (non-breaking)

```bash
cargo test -p tip-verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transaction hash-based tip lookup
  * Added artist tip enumeration and counting capabilities
  * Added indexed tip retrieval with boundary validation
  * Implemented duplicate transaction hash protection

* **Tests**
  * Expanded test coverage for index-based queries and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->