### PR TITLE
Envelope

### DIFF
--- a/backend/API_REFERENCE.md
+++ b/backend/API_REFERENCE.md
@@ -1,0 +1,207 @@
+# TipTune Backend API Reference
+
+This reference is derived from Nest controller annotations in `backend/src/**/controllers/*.ts`.
+The backend uses URI versioning behind `/api`, with the default version taken from `API_VERSION` (usually `v1`).
+
+- Base URL: `http://localhost:3001`
+- Swagger UI: `http://localhost:3001/api/docs`
+- Versioned API base: `/api/v1`
+- Non-versioned probes: `/api/health`, `/api/ready`, `/api/live`
+- Version metadata: `/api/version`
+
+---
+
+## Auth
+
+Authentication is wallet-based and challenge-response driven.
+
+### `POST /api/v1/auth/challenge`
+Request body:
+```json
+{ "publicKey": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" }
+```
+Returns a challenge string to sign with a Stellar wallet.
+
+### `POST /api/v1/auth/verify`
+Request body:
+```json
+{
+  "publicKey": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "challenge": "...",
+  "signature": "..."
+}
+```
+Response includes JWT tokens and sets secure cookies:
+- `access_token`
+- `refresh_token`
+
+### `POST /api/v1/auth/refresh`
+Uses either:
+- `refresh_token` cookie
+- `Authorization: Bearer <refresh_token>` header
+
+Response returns a refreshed access token and updates the `access_token` cookie.
+
+### `POST /api/v1/auth/logout`
+Requires authentication; invalidates refresh state and clears cookies.
+
+### `GET /api/v1/auth/me`
+Requires authentication; returns the currently authenticated user.
+
+---
+
+## Users / Artists
+
+All `artists` routes require authentication via JWT/cookie.
+
+### `POST /api/v1/artists`
+Create an artist profile for the logged-in user.
+
+### `GET /api/v1/artists`
+List artists with pagination.
+
+### `GET /api/v1/artists/me`
+Get the current user’s artist profile.
+
+### `PATCH /api/v1/artists/me`
+Update the current user’s artist profile.
+
+### `DELETE /api/v1/artists/me`
+Soft-delete the current user’s artist profile.
+
+### `POST /api/v1/artists/:artistId/restore`
+Restore a soft-deleted artist (admin/owner guard applies).
+
+---
+
+## Tracks
+
+### `POST /api/v1/tracks`
+Create a new track. Supports multipart file upload for `file`.
+
+### `GET /api/v1/tracks`
+List tracks with pagination and filters.
+Supported query parameters include: `page`, `limit`, `sortBy`, `sortOrder`, `artistId`, `genre`, `album`, `isPublic`, `releaseDate`.
+
+### `GET /api/v1/tracks/public`
+List public tracks only.
+
+### `GET /api/v1/tracks/search`
+Search tracks by title or album.
+Required query parameter: `q`.
+Supports the same pagination/filter query parameters as `/tracks`.
+
+### `GET /api/v1/tracks/artist/:artistId`
+Get tracks by artist.
+
+### `GET /api/v1/tracks/genre/:genre`
+Get tracks by genre.
+
+### `GET /api/v1/tracks/:id`
+Get track by ID.
+
+### `PATCH /api/v1/tracks/:id`
+Update track metadata.
+
+### `PATCH /api/v1/tracks/:id/play`
+Increment the track play count.
+
+### `PATCH /api/v1/tracks/:id/tips`
+Add tip amount to a track’s totals.
+Request body requires `amount`.
+
+### `DELETE /api/v1/tracks/:id`
+Delete a track.
+
+---
+
+## Tips
+
+### `POST /api/v1/tips`
+Create a new tip record.
+Required headers:
+- `x-user-id`: tipper user ID
+- optional `Idempotency-Key`
+
+### `GET /api/v1/tips/:id`
+Get a tip by ID.
+
+### `GET /api/v1/tips/user/:userId/history`
+Get tip history for a user (tips sent by that user).
+
+### `GET /api/v1/tips/artist/:artistId/received`
+Get tips received by an artist.
+
+### `GET /api/v1/tips/artist/:artistId/stats`
+Get tip statistics for an artist.
+
+---
+
+## Search
+
+### `GET /api/v1/search`
+Full-text search for artists and tracks.
+Supported query parameters:
+- `q`
+- `type` (`artist` or `track`)
+- `genre`
+- `status`
+- `country`
+- `city`
+- `hasLocation`
+- `isVerified`
+- `releaseDateFrom`
+- `releaseDateTo`
+- `sort`
+- `page`
+- `limit`
+
+### `GET /api/v1/search/suggestions`
+Autocomplete suggestions for artists and tracks.
+Supported query parameters:
+- `q` (partial search)
+- `type`
+- `limit`
+
+### `GET /api/v1/tracks/search`
+Track-specific search by title or album.
+Required query parameter: `q`.
+
+---
+
+## Admin
+
+The following endpoints are protected by admin guards or owner-level access.
+
+### Reports
+- `GET /api/v1/reports`
+- `GET /api/v1/reports/:id`
+- `PATCH /api/v1/reports/:id/status`
+- `PATCH /api/v1/reports/:id/assign`
+- `PATCH /api/v1/reports/:id/escalate`
+
+### Verification admin
+- `GET /api/v1/verification/admin/pending`
+- `PATCH /api/v1/verification/admin/requests/:id/review`
+- `GET /api/v1/verification/admin/stats`
+
+### Rate limit metrics
+- `GET /api/v1/admin/rate-limits/metrics`
+- `GET /api/v1/admin/rate-limits/endpoints`
+- `GET /api/v1/admin/rate-limits/top-ips`
+- `GET /api/v1/admin/rate-limits/suspicious-ips`
+- `GET /api/v1/admin/rate-limits/summary`
+- `POST /api/v1/admin/rate-limits/reset`
+
+---
+
+## Health and Version
+
+### `GET /api/version`
+Returns current API version metadata.
+
+### `GET /api/health`
+### `GET /api/ready`
+### `GET /api/live`
+
+These endpoints are excluded from the `/api` global prefix versioning stack and remain version-neutral.

--- a/backend/ERROR_ENVELOPE_MIGRATION.md
+++ b/backend/ERROR_ENVELOPE_MIGRATION.md
@@ -4,6 +4,9 @@
 
 This guide explains the new consistent error handling system implemented across the Tip-Tune backend. All API endpoints now return errors in a standardized format using a global exception filter.
 
+This repository also maintains a living module rollout status matrix in `ERROR_ENVELOPE_STATUS.md`.
+Use that file to see which controllers/services are migrated, partially migrated, or still using legacy Nest exception classes.
+
 ## Error Response Format
 
 All errors now follow this consistent envelope:
@@ -70,6 +73,9 @@ throw new ApiException('Error message', HttpStatus.BAD_REQUEST);
 ```
 
 ### Specific Exceptions
+
+All preferred custom exception classes are defined in `backend/src/common/exceptions/api-exception.ts`.
+Use these classes instead of Nest built-in exceptions for consistent error envelope output.
 
 #### ResourceNotFoundException (404)
 ```typescript
@@ -200,6 +206,11 @@ All error responses include these headers:
 - `X-Error-ID`: Unique error identifier for tracking
 - `X-Timestamp`: When the error occurred
 - `Content-Type`: application/json
+
+## Migration status and checklist
+
+For module-level rollout status, see `ERROR_ENVELOPE_STATUS.md`.
+That file is the living source of truth for whether a module still throws Nest standard exceptions or has adopted the shared custom exception classes.
 
 ## Testing
 

--- a/backend/ERROR_ENVELOPE_STATUS.md
+++ b/backend/ERROR_ENVELOPE_STATUS.md
@@ -1,0 +1,94 @@
+# Error Envelope Rollout Status
+
+This file tracks the current migration state of backend modules for the standardized error envelope.
+It is a living checklist tied to the actual controller/service modules in `backend/src/`.
+
+## Purpose
+
+- Show which modules still use legacy Nest exception classes directly.
+- Show which modules have started using the preferred custom exceptions.
+- Point teams to the controller/service files that should be audited next.
+
+## Preferred exception classes
+
+All custom API exceptions are defined in:
+
+- `backend/src/common/exceptions/api-exception.ts`
+
+Preferred classes:
+
+- `ApiException`
+- `ResourceNotFoundException`
+- `ValidationException`
+- `AuthenticationException`
+- `AuthorizationException`
+- `ConflictException`
+- `ResourceGoneException`
+- `RateLimitException`
+- `ExternalServiceException`
+- `DatabaseException`
+- `FileUploadException`
+
+Use these instead of Nest built-ins such as:
+
+- `BadRequestException`
+- `NotFoundException`
+- `UnauthorizedException`
+- `ForbiddenException`
+- `ConflictException` (Nest)
+- `HttpException`
+
+## Status Matrix
+
+| Module | Representative files | Status | Notes |
+|---|---|---|---|
+| activities | `src/activities/activities.controller.ts`, `src/activities/activities.service.ts` | Unmigrated | uses Nest `NotFoundException` in service layer |
+| admin | `src/admin/...` | Unmigrated | uses Nest `BadRequestException`, `ForbiddenException`, `NotFoundException`, `UnauthorizedException` |
+| artist-status | `src/artist-status/...` | Unmigrated | uses Nest `BadRequestException`, `NotFoundException` |
+| artiste-payout | `src/artiste-payout/payouts.controller.ts`, `src/artiste-payout/payouts.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `ForbiddenException`, `NotFoundException` |
+| artists | `src/artists/artists.controller.ts`, `src/artists/artists.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException`, `UnauthorizedException` |
+| assets | `src/assets/assets.controller.ts` | Unmigrated | uses Nest `NotFoundException` |
+| auth | `src/auth/auth.controller.ts`, `src/auth/auth.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `UnauthorizedException` |
+| blocks | `src/blocks/blocks.controller.ts`, `src/blocks/blocks.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| collaboration | `src/collaboration/...` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException` |
+| comments | `src/comments/comments.controller.ts`, `src/comments/comments.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException` |
+| common | `src/common/filters/global-exception.filter.ts` | Migrated | global filter is in place and wraps exceptions into the envelope |
+| embed | `src/embed/embed.service.ts` | Unmigrated | still throws Nest `ForbiddenException`, `NotFoundException` |
+| events | `src/events/events.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException` |
+| events-live-show | `src/events-live-show/events.controller.ts`, `src/events-live-show/events.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `ForbiddenException`, `NotFoundException` |
+| follows | `src/follows/follows.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| genres | `src/genres/genres.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| goals | `src/goals/goals.service.ts` | Unmigrated | still throws Nest `ForbiddenException`, `NotFoundException` |
+| moderation | `src/moderation/moderation.controller.ts` | Unmigrated | still throws Nest `BadRequestException` |
+| notifications | `src/notifications/notifications.controller.ts` | Unmigrated | still throws Nest `NotFoundException` |
+| platinum-fee | `src/platinum-fee/fees.controller.ts`, `src/platinum-fee/fees.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `NotFoundException` |
+| playlists | `src/playlists/playlists.controller.ts`, `src/playlists/playlists.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException` |
+| reports | `src/reports/reports.controller.ts`, `src/reports/reports.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `NotFoundException` |
+| scheduled-releases | `src/scheduled-releases/presaves.service.ts`, `src/scheduled-releases/scheduled-releases.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `NotFoundException` |
+| social-sharing | `src/social-sharing/referral.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| standardized-subscription | `src/standardized-subscription/subscriptions.service.ts` | Unmigrated | still throws Nest `ConflictException`, `ForbiddenException`, `NotFoundException`, `UnauthorizedException` |
+| storage | `src/storage/storage.controller.ts`, `src/storage/storage.service.ts` | Unmigrated | still throws Nest `BadRequestException` |
+| subscription-tiers | `src/subscription-tiers/subscriptions.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `ForbiddenException`, `NotFoundException` |
+| subscriptions | `src/subscriptions/subscriptions.service.ts` | Unmigrated | still throws Nest `ConflictException`, `ForbiddenException`, `NotFoundException` |
+| tips | `src/tips/tips.controller.ts`, `src/tips/tips.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| track-listening-right-management | `src/track-listening-right-management/licensing.controller.ts`, `src/track-listening-right-management/licensing.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ForbiddenException`, `NotFoundException` |
+| track-play-count | `src/track-play-count/play-count.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `NotFoundException` |
+| tracks | `src/tracks/tracks.controller.ts`, `src/tracks/tracks.service.ts` | Partial | `tracks.service.ts` uses `ResourceNotFoundException`; other Nest exceptions remain in service/controller code |
+| users | `src/users/users.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `ForbiddenException`, `NotFoundException`, `UnauthorizedException` |
+| verification | `src/verification/verification.controller.ts`, `src/verification/verification.service.ts` | Unmigrated | still throws Nest `BadRequestException`, `ConflictException`, `NotFoundException` |
+| version | `src/version/version.controller.ts` | Unmigrated | no custom exceptions used yet |
+| waveform | `src/waveform/**/*.ts` | Unmigrated | still throws Nest `NotFoundException` |
+
+## How to use this checklist
+
+1. Update the module status when you migrate a controller or service to custom exceptions.
+2. Prefer the shared exceptions defined in `backend/src/common/exceptions/api-exception.ts`.
+3. Keep the global exception filter in `backend/src/common/filters/global-exception.filter.ts` as the single envelope formatter.
+4. For partial migrations, note the service/controller file that still emits legacy Nest exceptions.
+
+## Sample audit notes
+
+- `tracks` is currently the only module with a custom exception import from `backend/src/common/exceptions/api-exception.ts`.
+- `auth`, `artists`, `reports`, and `users` remain legacy-critical because they still directly throw Nest exception classes.
+
+> Important: this matrix reflects the current source tree and should be updated whenever a migration is completed for a module.

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,8 @@ A professional NestJS backend service for audio file upload, storage, and stream
 ## Documentation
 
 - [Docs index](../docs/README.md)
-- [Backend API documentation](api-documentation.md)
+- [Backend API reference](API_REFERENCE.md)
+- [Backend API documentation alias](api-documentation.md)
 - [Backend testing guide](TESTING.md)
 - [Developer onboarding](dev-onboarding.md)
 
@@ -87,7 +88,7 @@ npm run start:prod
 
 Once running, visit `http://localhost:3001/api/docs` for interactive API documentation.
 API routes are versioned under `/api/v1/*` (except health probes and `/api/version`).
-The normalized repository doc for the backend surface lives at [api-documentation.md](api-documentation.md).
+The normalized repository doc for the backend surface is now maintained in [API_REFERENCE.md](API_REFERENCE.md) and exposed through [api-documentation.md](api-documentation.md).
 
 ## API Endpoints
 

--- a/backend/api -documentation.md
+++ b/backend/api -documentation.md
@@ -2,14 +2,12 @@
 
 This legacy file name is kept so older links and bookmarks still resolve.
 
-Use the normalized path instead:
+Use the maintained API reference instead:
 
+- [API_REFERENCE.md](API_REFERENCE.md)
 - [api-documentation.md](api-documentation.md)
 - [Backend README](README.md)
 - [Docs index](../docs/README.md)
-
-- XLM (Native)
-- USDC (Stellar Asset)
 
 ---
 

--- a/backend/api-documentation.md
+++ b/backend/api-documentation.md
@@ -1,21 +1,10 @@
 # TipTune Backend API Documentation
 
-This is the normalized repository path for backend API documentation.
+This normalized backend API documentation path now points to the maintained reference in `API_REFERENCE.md`.
 
-## Primary references
-
-- Interactive Swagger UI: `http://localhost:3001/api/docs`
-- Base path: `/api/v1/*` except health probes and `/api/version`
-- Service overview: [README.md](README.md)
-
-## Coverage
-
-- Authentication and JWT flows
-- User and artist profile endpoints
-- Track upload and streaming routes
-- Search and autocomplete endpoints
-- Tip history and transaction status
-- WebSocket event surface
+- Canonical API reference: [API_REFERENCE.md](API_REFERENCE.md)
+- Swagger UI: `http://localhost:3001/api/docs`
+- Versioned API base: `/api/v1`
 
 ## Navigation
 
@@ -23,6 +12,6 @@ This is the normalized repository path for backend API documentation.
 - Use [TESTING.md](TESTING.md) for backend validation commands.
 - Use [../docs/README.md](../docs/README.md) for the repo-wide documentation map.
 
-## Note on naming
+## Compatibility
 
-The legacy file name [api -documentation.md](api%20-documentation.md) is kept as a compatibility redirect so existing bookmarks do not break.
+The legacy file name [api -documentation.md](api%20-documentation.md) remains available for older bookmarks.


### PR DESCRIPTION
 Error Envelope Rollout Status Matrix

Problem: backend/ERROR_ENVELOPE_MIGRATION.md explains the target format but not which modules still use legacy exceptions. Scope: document migration status and remaining gaps by module. Implementation guidance: create a living checklist tied to current controllers/services instead of a one-time migration note.
Acceptance criteria: teams can identify migrated vs unmigrated modules at a glance and know the preferred exception classes. Validation: sample controller/service audit against the status matrix. Files to modify: backend/ERROR_ENVELOPE_MIGRATION.md. 
closes #473

 Root README Monorepo Accuracy Pass


Problem: README.md describes generic setup paths and links to missing docs like docs/search-ranking-algorithm.md. Scope: Rewrite the root entry doc around the actual frontend/backend/contracts layout. Implementation guidance: verify every path and startup command against the current repo instead of inherited boilerplate.
Acceptance criteria: root setup works from a clean checkout, project structure matches the repo, and broken internal links are removed. Validation: manual link/path audit plus command review from README steps. Files to modify: README.md. Files to create: docs/monorepo-overview.md.
closes #468