### PR TITLE
Add immutable badge mint receipts and chronological user receipt quer…

### DIFF
--- a/contracts/tip-nft-badge/src/catalog.rs
+++ b/contracts/tip-nft-badge/src/catalog.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{symbol_short, Address, Env, String};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String};
 
-use crate::{BadgeType, DataKey, Error};
+use crate::{BadgeType, DataKey};
 
 /// Configurable catalog entry for a badge type.
 ///

--- a/contracts/tip-nft-badge/src/lib.rs
+++ b/contracts/tip-nft-badge/src/lib.rs
@@ -1,12 +1,14 @@
 #![no_std]
 
 mod catalog;
+mod receipts;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
 };
 
 pub use catalog::{BadgeCatalogEntry, CatalogKey};
+pub use receipts::BadgeMintReceipt;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -59,8 +61,10 @@ pub enum DataKey {
     Admin,
     UserStats(Address),
     UserBadges(Address),
+    UserBadgeReceipts(Address),
     BadgeMinted(Address, u32), // user + badge_type ordinal
     BadgeRecord(String),
+    BadgeReceipt(String),
     TotalBadges,
     EarlyAdopterThreshold,
     WhaleThreshold,
@@ -223,6 +227,16 @@ impl TipNftBadgeContract {
             .persistent()
             .set(&DataKey::BadgeRecord(badge_id.clone()), &metadata);
 
+        let receipt = receipts::BadgeMintReceipt {
+            badge_id: badge_id.clone(),
+            badge_type,
+            name: metadata.name.clone(),
+            description: metadata.description.clone(),
+            owner: user.clone(),
+            minted_at: metadata.minted_at,
+        };
+        receipts::set_badge_receipt(&env, &receipt);
+
         let mut user_badges: Vec<String> = env
             .storage()
             .persistent()
@@ -232,6 +246,8 @@ impl TipNftBadgeContract {
         env.storage()
             .persistent()
             .set(&DataKey::UserBadges(user.clone()), &user_badges);
+
+        receipts::append_user_receipt(&env, user.clone(), &badge_id);
 
         env.events()
             .publish((symbol_short!("badge"), symbol_short!("minted")), metadata);
@@ -257,6 +273,16 @@ impl TipNftBadgeContract {
             }
         }
         full_badges
+    }
+
+    /// Get user badge mint receipts in chronological order.
+    pub fn get_user_badge_receipts(env: Env, user: Address) -> Vec<BadgeMintReceipt> {
+        receipts::get_user_badge_receipts(&env, user)
+    }
+
+    /// Get badge mint receipt by badge ID.
+    pub fn get_badge_receipt(env: Env, badge_id: String) -> Option<BadgeMintReceipt> {
+        receipts::get_badge_receipt(&env, badge_id)
     }
 
     /// Get badge metadata by ID

--- a/contracts/tip-nft-badge/src/receipts.rs
+++ b/contracts/tip-nft-badge/src/receipts.rs
@@ -1,0 +1,56 @@
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
+
+use crate::{BadgeType, DataKey};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeMintReceipt {
+    pub badge_id: String,
+    pub badge_type: BadgeType,
+    pub name: String,
+    pub description: String,
+    pub owner: Address,
+    pub minted_at: u64,
+}
+
+pub fn set_badge_receipt(env: &Env, receipt: &BadgeMintReceipt) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::BadgeReceipt(receipt.badge_id.clone()), receipt);
+}
+
+pub fn get_badge_receipt(env: &Env, badge_id: String) -> Option<BadgeMintReceipt> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::BadgeReceipt(badge_id))
+}
+
+pub fn append_user_receipt(env: &Env, user: Address, badge_id: &String) {
+    let mut user_receipts: Vec<String> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::UserBadgeReceipts(user.clone()))
+        .unwrap_or(Vec::new(env));
+    user_receipts.push_back(badge_id.clone());
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserBadgeReceipts(user), &user_receipts);
+}
+
+pub fn get_user_badge_receipt_ids(env: &Env, user: Address) -> Vec<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserBadgeReceipts(user))
+        .unwrap_or(Vec::new(env))
+}
+
+pub fn get_user_badge_receipts(env: &Env, user: Address) -> Vec<BadgeMintReceipt> {
+    let ids = get_user_badge_receipt_ids(env, user);
+    let mut receipts = Vec::new(env);
+    for id in ids {
+        if let Some(receipt) = get_badge_receipt(env, id) {
+            receipts.push_back(receipt);
+        }
+    }
+    receipts
+}

--- a/contracts/tip-nft-badge/src/test.rs
+++ b/contracts/tip-nft-badge/src/test.rs
@@ -293,6 +293,54 @@ fn test_multiple_badges_per_user() {
 }
 
 #[test]
+fn test_badge_receipt_creation_and_query() {
+    let env = setup_env(1000);
+    let contract_id = env.register_contract(None, TipNftBadgeContract);
+    let client = TipNftBadgeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &10000, &5000);
+
+    let user = Address::generate(&env);
+    client.record_tip(&user, &100, &false);
+    let badge_id = client.mint_badge(&user, &BadgeType::FirstTip);
+
+    let receipt = client.get_badge_receipt(&badge_id).unwrap();
+    assert_eq!(receipt.badge_id, badge_id);
+    assert_eq!(receipt.owner, user);
+    assert_eq!(receipt.badge_type, BadgeType::FirstTip);
+    assert_eq!(receipt.minted_at, 1000);
+    assert_eq!(receipt.name, String::from_str(&env, "First Tip"));
+}
+
+#[test]
+fn test_user_badge_receipts_are_chronological() {
+    let env = setup_env(1000);
+    let contract_id = env.register_contract(None, TipNftBadgeContract);
+    let client = TipNftBadgeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &10000, &5000);
+
+    let user = Address::generate(&env);
+    for _ in 0..10 {
+        client.record_tip(&user, &100, &false);
+    }
+
+    let badge1 = client.mint_badge(&user, &BadgeType::FirstTip);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 2000;
+    });
+    let badge2 = client.mint_badge(&user, &BadgeType::TenTips);
+
+    let receipts = client.get_user_badge_receipts(&user);
+    assert_eq!(receipts.len(), 2);
+    assert_eq!(receipts.get(0).unwrap().badge_id, badge1);
+    assert_eq!(receipts.get(1).unwrap().badge_id, badge2);
+    assert!(receipts.get(0).unwrap().minted_at < receipts.get(1).unwrap().minted_at);
+}
+
+#[test]
 fn test_user_with_no_badges() {
     let env = setup_env(1000);
     let contract_id = env.register_contract(None, TipNftBadgeContract);


### PR DESCRIPTION
close #527 

### PR summary

**Title**
Add immutable badge mint receipts and chronological user receipt queries for tip-nft-badge

**Changes**
- Added receipts.rs
- Added immutable `BadgeMintReceipt` storage
- Appended per-user chronological receipt index
- Added query methods:
  - `get_badge_receipt(...)`
  - `get_user_badge_receipts(...)`
- Added tests covering receipt creation and ordering
- Fixed `contracttype` import in catalog.rs